### PR TITLE
fix: resolve all golangci-lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,30 @@ linters:
     - dupl
     - bodyclose
     - noctx
+  settings:
+    revive:
+      rules:
+        - name: var-naming
+          disabled: false
+          arguments:
+            - []
+            - []
+            - - skipPackageNameChecks: true
+
+  exclusions:
+    rules:
+      # G706: False positive — we log len(targetDevices), not raw user input
+      - path: internal/metrics/collector\.go
+        linters: [gosec]
+        text: "G706"
+      # G704: False positive — URL built from validated hostname, not arbitrary user input
+      - path: internal/metrics/scraper\.go
+        linters: [gosec]
+        text: "G704"
+      # G101: False positive — test data, not real credentials
+      - path: _test\.go
+        linters: [gosec]
+        text: "G101"
 
 issues:
   max-issues-per-linter: 50

--- a/cmd/tsmetrics/main.go
+++ b/cmd/tsmetrics/main.go
@@ -65,12 +65,16 @@ func performHealthCheck() error {
 	if host == "" {
 		host = "127.0.0.1" // DevSkim: ignore DS162092 - Localhost is appropriate for health checks
 	}
-	url := fmt.Sprintf("http://%s:%s/livez", host, cfg.Port)
-	resp, err := client.Get(url)
+	healthURL := fmt.Sprintf("http://%s:%s/livez", host, cfg.Port)
+	req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, healthURL, nil)
+	if reqErr != nil {
+		return fmt.Errorf("health check request failed: %w", reqErr)
+	}
+	resp, err := client.Do(req) //nolint:gosec // URL constructed from local config, not user input
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("health check failed: status %d", resp.StatusCode)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -29,7 +29,7 @@ func NewClient(clientID, clientSecret, tailnet string) *Client {
 	var httpClient *http.Client
 
 	if clientID != "" && clientSecret != "" {
-		config := &clientcredentials.Config{
+		config := &clientcredentials.Config{ //nolint:gosec // G101: not hardcoded credentials, passed as parameters
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			TokenURL:     "https://api.tailscale.com/api/v2/oauth/token",
@@ -99,7 +99,7 @@ func (c *Client) FetchDevices() ([]device.Device, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.handleAPIError(resp)
@@ -129,12 +129,12 @@ func (c *Client) FetchDevices() ([]device.Device, error) {
 
 func (c *Client) makeDevicesRequest() (*http.Response, error) {
 	apiURL := fmt.Sprintf("%s/devices?fields=all", c.baseURL)
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // URL is constructed from configured baseURL, not user input
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -386,11 +386,11 @@ func (c *Client) TestConnectivity(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // URL from configured baseURL
 	if err != nil {
 		return false, fmt.Errorf("connectivity test failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return true, nil
@@ -419,16 +419,16 @@ type deviceRoutes struct {
 
 func (c *Client) fetchDeviceRoutes(deviceID string) (*deviceRoutes, error) {
 	apiURL := fmt.Sprintf("https://api.tailscale.com/api/v2/device/%s/routes?fields=all", deviceID)
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create routes request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // URL is constructed from known API base + validated device ID
 	if err != nil {
 		return nil, fmt.Errorf("routes request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("routes API returned status %d", resp.StatusCode)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -99,8 +99,9 @@ func TestClientFetchDevices(t *testing.T) {
 		requests:  make([]*http.Request, 0),
 	}
 
-	mockTransport.responses["https://api.tailscale.com/api/v2/tailnet/test-tailnet/devices?fields=all"] =
-		createMockResponse(200, responseBody)
+	devicesResp := createMockResponse(200, responseBody)
+	t.Cleanup(func() { _ = devicesResp.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/tailnet/test-tailnet/devices?fields=all"] = devicesResp
 
 	// Add mock responses for route API calls
 	routesResponse1 := map[string][]string{
@@ -111,10 +112,12 @@ func TestClientFetchDevices(t *testing.T) {
 		"advertisedRoutes": {"192.168.1.0/24"},
 		"enabledRoutes":    {"192.168.1.0/24"},
 	}
-	mockTransport.responses["https://api.tailscale.com/api/v2/device/device1/routes?fields=all"] =
-		createMockResponse(200, routesResponse1)
-	mockTransport.responses["https://api.tailscale.com/api/v2/device/device2/routes?fields=all"] =
-		createMockResponse(200, routesResponse2)
+	routesResp1 := createMockResponse(200, routesResponse1)
+	t.Cleanup(func() { _ = routesResp1.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/device/device1/routes?fields=all"] = routesResp1
+	routesResp2 := createMockResponse(200, routesResponse2)
+	t.Cleanup(func() { _ = routesResp2.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/device/device2/routes?fields=all"] = routesResp2
 
 	client := &Client{
 		httpClient: &http.Client{
@@ -158,8 +161,9 @@ func TestClientFetchDevicesError(t *testing.T) {
 		requests:  make([]*http.Request, 0),
 	}
 
-	mockTransport.responses["https://api.tailscale.com/api/v2/tailnet/test-tailnet/devices?fields=all"] =
-		createMockResponse(500, "Internal Server Error")
+	errResp := createMockResponse(500, "Internal Server Error")
+	t.Cleanup(func() { _ = errResp.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/tailnet/test-tailnet/devices?fields=all"] = errResp
 
 	client := &Client{
 		httpClient: &http.Client{
@@ -192,7 +196,7 @@ func TestClientWithRealServer(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(response)
+			_ = json.NewEncoder(w).Encode(response)
 			return
 		}
 		http.NotFound(w, r)
@@ -333,8 +337,9 @@ func TestClientExitNodeDetection(t *testing.T) {
 		"devices": devices,
 	}
 
-	mockTransport.responses["https://api.tailscale.com/api/v2/tailnet/test-tailnet/devices?fields=all"] =
-		createMockResponse(200, responseBody)
+	devResp := createMockResponse(200, responseBody)
+	t.Cleanup(func() { _ = devResp.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/tailnet/test-tailnet/devices?fields=all"] = devResp
 
 	// Mock route responses for different device types
 	exitNodeRoutes := map[string][]string{
@@ -350,12 +355,15 @@ func TestClientExitNodeDetection(t *testing.T) {
 		"enabledRoutes":    {},
 	}
 
-	mockTransport.responses["https://api.tailscale.com/api/v2/device/exit-node-device/routes?fields=all"] =
-		createMockResponse(200, exitNodeRoutes)
-	mockTransport.responses["https://api.tailscale.com/api/v2/device/subnet-router-device/routes?fields=all"] =
-		createMockResponse(200, subnetRouterRoutes)
-	mockTransport.responses["https://api.tailscale.com/api/v2/device/regular-device/routes?fields=all"] =
-		createMockResponse(200, regularDeviceRoutes)
+	exitResp := createMockResponse(200, exitNodeRoutes)
+	t.Cleanup(func() { _ = exitResp.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/device/exit-node-device/routes?fields=all"] = exitResp
+	subnetResp := createMockResponse(200, subnetRouterRoutes)
+	t.Cleanup(func() { _ = subnetResp.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/device/subnet-router-device/routes?fields=all"] = subnetResp
+	regularResp := createMockResponse(200, regularDeviceRoutes)
+	t.Cleanup(func() { _ = regularResp.Body.Close() })
+	mockTransport.responses["https://api.tailscale.com/api/v2/device/regular-device/routes?fields=all"] = regularResp
 
 	client := &Client{
 		httpClient: &http.Client{
@@ -365,17 +373,17 @@ func TestClientExitNodeDetection(t *testing.T) {
 		baseURL: "https://api.tailscale.com/api/v2/tailnet/test-tailnet",
 	}
 
-	devices_result, err := client.FetchDevices()
+	devicesResult, err := client.FetchDevices()
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	if len(devices_result) != 3 {
-		t.Errorf("Expected 3 devices, got %d", len(devices_result))
+	if len(devicesResult) != 3 {
+		t.Errorf("Expected 3 devices, got %d", len(devicesResult))
 	}
 
 	// Test exit node device
-	exitNode := devices_result[0]
+	exitNode := devicesResult[0]
 	if !exitNode.IsExitNode {
 		t.Error("Expected exit-node-device to be an exit node")
 	}
@@ -384,7 +392,7 @@ func TestClientExitNodeDetection(t *testing.T) {
 	}
 
 	// Test subnet router + exit node device
-	subnetRouter := devices_result[1]
+	subnetRouter := devicesResult[1]
 	if !subnetRouter.IsExitNode {
 		t.Error("Expected subnet-router-device to be an exit node")
 	}
@@ -393,7 +401,7 @@ func TestClientExitNodeDetection(t *testing.T) {
 	}
 
 	// Test regular device
-	regular := devices_result[2]
+	regular := devicesResult[2]
 	if regular.IsExitNode {
 		t.Error("Expected regular-device NOT to be an exit node")
 	}

--- a/internal/cache/device_cache_test.go
+++ b/internal/cache/device_cache_test.go
@@ -292,7 +292,7 @@ func TestDeviceCache_GetCacheStats(t *testing.T) {
 		t.Errorf("Expected 1 device, got %d", len(devices))
 	}
 
-	cache.GetDevices(false)
+	_, _ = cache.GetDevices(false)
 
 	stats := cache.GetCacheStats()
 	if stats.HitCount != 1 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	TsnetAuthKey         string
 	Port                 string
 	OAuthClientID        string
-	OAuthSecret          string
+	OAuthSecret          string //nolint:gosec // G117: not a hardcoded credential, loaded from env
 	TailnetName          string
 	ClientMetricsTimeout time.Duration
 	MaxConcurrentScrapes int

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,21 +9,21 @@ import (
 func TestConfigLoad(t *testing.T) {
 	os.Clearenv()
 
-	os.Setenv("USE_TSNET", "true")
-	os.Setenv("TSNET_HOSTNAME", "test-hostname")
-	os.Setenv("TSNET_STATE_DIR", "/tmp/test")
-	os.Setenv("TS_AUTHKEY", "tskey-test")
-	os.Setenv("PORT", "8080")
-	os.Setenv("OAUTH_CLIENT_ID", "test-client")
-	os.Setenv("OAUTH_CLIENT_SECRET", "test-secret")
-	os.Setenv("TAILNET_NAME", "test-tailnet")
-	os.Setenv("CLIENT_METRICS_TIMEOUT", "15s")
-	os.Setenv("MAX_CONCURRENT_SCRAPES", "20")
-	os.Setenv("LOG_LEVEL", "debug")
-	os.Setenv("LOG_FORMAT", "json")
-	os.Setenv("CLIENT_METRICS_PORT", "5353")
-	os.Setenv("TSNET_TAGS", "exporter,monitoring")
-	os.Setenv("SCRAPE_TAG", "production")
+	t.Setenv("USE_TSNET", "true")
+	t.Setenv("TSNET_HOSTNAME", "test-hostname")
+	t.Setenv("TSNET_STATE_DIR", "/tmp/test")
+	t.Setenv("TS_AUTHKEY", "tskey-test")
+	t.Setenv("PORT", "8080")
+	t.Setenv("OAUTH_CLIENT_ID", "test-client")
+	t.Setenv("OAUTH_CLIENT_SECRET", "test-secret")
+	t.Setenv("TAILNET_NAME", "test-tailnet")
+	t.Setenv("CLIENT_METRICS_TIMEOUT", "15s")
+	t.Setenv("MAX_CONCURRENT_SCRAPES", "20")
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("LOG_FORMAT", "json")
+	t.Setenv("CLIENT_METRICS_PORT", "5353")
+	t.Setenv("TSNET_TAGS", "exporter,monitoring")
+	t.Setenv("SCRAPE_TAG", "production")
 
 	cfg := Load()
 
@@ -206,7 +206,7 @@ func TestConfigValidate(t *testing.T) {
 			os.Clearenv()
 
 			for key, value := range tt.envVars {
-				os.Setenv(key, value)
+				t.Setenv(key, value)
 			}
 
 			err := tt.config.Validate()
@@ -229,7 +229,7 @@ func TestSetupTsnetStateDir(t *testing.T) {
 		t.Errorf("Expected custom dir '%s', got %s", customDir, dir)
 	}
 
-	defer os.RemoveAll(customDir)
+	defer func() { _ = os.RemoveAll(customDir) }()
 	if _, err := os.Stat(customDir); os.IsNotExist(err) {
 		t.Errorf("Expected directory %s to be created", customDir)
 	}

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -186,7 +186,7 @@ func TestAPIHealthChecker(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/api/v2/device") {
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"devices": []}`))
+			_, _ = w.Write([]byte(`{"devices": []}`))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -64,7 +64,7 @@ func (c *Collector) FetchDevices() ([]device.Device, error) {
 				targetDevices = append(targetDevices, p)
 			}
 		}
-		slog.Debug("TARGET_DEVICES specified", "devices", targetDevices)
+		slog.Debug("TARGET_DEVICES specified", "count", len(targetDevices))
 	}
 
 	if len(targetDevices) == 0 {
@@ -77,7 +77,7 @@ func (c *Collector) FetchDevices() ([]device.Device, error) {
 			}
 			testDevicesWarningMutex.Lock()
 			if !testDevicesWarningShown {
-				slog.Warn("TEST_DEVICES is deprecated, use TARGET_DEVICES instead", "devices", targetDevices)
+				slog.Warn("TEST_DEVICES is deprecated, use TARGET_DEVICES instead", "count", len(targetDevices))
 				testDevicesWarningShown = true
 			}
 			testDevicesWarningMutex.Unlock()
@@ -129,7 +129,7 @@ func (c *Collector) FetchDevices() ([]device.Device, error) {
 				Online: true,
 			})
 		}
-		slog.Info("using TARGET_DEVICES as static device list", "devices", targetDevices)
+		slog.Info("using TARGET_DEVICES as static device list", "count", len(targetDevices))
 		return out, nil
 	}
 

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -175,7 +175,7 @@ func scrapeClient(dev device.Device, client *http.Client, cfg config.Config) err
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return handleHTTPError(dev, resp, buildMetricsURL(dev, cfg))
@@ -205,7 +205,11 @@ func fetchDeviceMetrics(dev device.Device, client *http.Client, cfg config.Confi
 	}
 
 	urlStr := buildMetricsURL(dev, cfg)
-	resp, err := client.Get(urlStr)
+	req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, urlStr, nil)
+	if reqErr != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", urlStr, reqErr)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		deviceErr := errors.DeviceError{
 			DeviceID:   dev.ID.String(),

--- a/internal/metrics/strategies.go
+++ b/internal/metrics/strategies.go
@@ -146,6 +146,7 @@ func (s *SequentialStrategy) Execute(ctx context.Context, devices []device.Devic
 	return nil
 }
 
+// NewParallelStrategy creates a strategy that scrapes devices concurrently with a concurrency limit.
 func NewParallelStrategy(collector MetricCollector, interval, timeout time.Duration, concurrency int) *ParallelStrategy {
 	return &ParallelStrategy{
 		collector:   collector,
@@ -155,10 +156,12 @@ func NewParallelStrategy(collector MetricCollector, interval, timeout time.Durat
 	}
 }
 
+// Name returns the strategy name.
 func (s *ParallelStrategy) Name() string {
 	return "parallel"
 }
 
+// Validate checks that the strategy configuration is valid.
 func (s *ParallelStrategy) Validate() error {
 	if s.collector == nil {
 		return errors.ErrInvalidCollector
@@ -175,6 +178,7 @@ func (s *ParallelStrategy) Validate() error {
 	return nil
 }
 
+// Execute scrapes all devices concurrently up to the configured concurrency limit.
 func (s *ParallelStrategy) Execute(ctx context.Context, devices []device.Device) error {
 	start := time.Now()
 	defer func() {
@@ -223,6 +227,7 @@ func (s *ParallelStrategy) Execute(ctx context.Context, devices []device.Device)
 	return lastErr
 }
 
+// NewPriorityStrategy creates a strategy that scrapes devices in priority group order.
 func NewPriorityStrategy(collector MetricCollector, interval, timeout time.Duration) *PriorityStrategy {
 	return &PriorityStrategy{
 		collector:      collector,
@@ -233,10 +238,12 @@ func NewPriorityStrategy(collector MetricCollector, interval, timeout time.Durat
 	}
 }
 
+// Name returns the strategy name.
 func (s *PriorityStrategy) Name() string {
 	return "priority"
 }
 
+// Validate checks that the strategy configuration is valid.
 func (s *PriorityStrategy) Validate() error {
 	if s.collector == nil {
 		return errors.ErrInvalidCollector
@@ -250,11 +257,13 @@ func (s *PriorityStrategy) Validate() error {
 	return nil
 }
 
+// AddPriorityGroup registers a named group of devices with a custom scrape interval.
 func (s *PriorityStrategy) AddPriorityGroup(groupName string, deviceIDs []types.DeviceID, interval time.Duration) {
 	s.priorityGroups[groupName] = deviceIDs
 	s.groupIntervals[groupName] = interval
 }
 
+// Execute scrapes devices sequentially within each priority group.
 func (s *PriorityStrategy) Execute(ctx context.Context, devices []device.Device) error {
 	start := time.Now()
 	defer func() {
@@ -296,6 +305,7 @@ func (s *PriorityStrategy) Execute(ctx context.Context, devices []device.Device)
 	return nil
 }
 
+// NewAdaptiveStrategy creates a strategy that adjusts concurrency based on device performance history.
 func NewAdaptiveStrategy(collector MetricCollector, baseInterval, timeout time.Duration, maxConcurrency int, loadThreshold float64) *AdaptiveStrategy {
 	return &AdaptiveStrategy{
 		collector:       collector,
@@ -307,10 +317,12 @@ func NewAdaptiveStrategy(collector MetricCollector, baseInterval, timeout time.D
 	}
 }
 
+// Name returns the strategy name.
 func (s *AdaptiveStrategy) Name() string {
 	return "adaptive"
 }
 
+// Validate checks that the strategy configuration is valid.
 func (s *AdaptiveStrategy) Validate() error {
 	if s.collector == nil {
 		return errors.ErrInvalidCollector
@@ -330,6 +342,7 @@ func (s *AdaptiveStrategy) Validate() error {
 	return nil
 }
 
+// Execute categorizes devices by performance and scrapes them with adaptive concurrency.
 func (s *AdaptiveStrategy) Execute(ctx context.Context, devices []device.Device) error {
 	start := time.Now()
 	defer func() {
@@ -340,10 +353,7 @@ func (s *AdaptiveStrategy) Execute(ctx context.Context, devices []device.Device)
 
 	for priority, devs := range deviceGroups {
 		concurrency := s.calculateConcurrency(priority)
-		err := s.processDeviceGroup(ctx, devs, concurrency)
-		if err != nil {
-			return err
-		}
+		s.processDeviceGroup(ctx, devs, concurrency)
 	}
 
 	return nil
@@ -391,9 +401,9 @@ func (s *AdaptiveStrategy) calculateConcurrency(priority string) int {
 	}
 }
 
-func (s *AdaptiveStrategy) processDeviceGroup(ctx context.Context, devices []device.Device, concurrency int) error {
+func (s *AdaptiveStrategy) processDeviceGroup(ctx context.Context, devices []device.Device, concurrency int) {
 	if len(devices) == 0 {
-		return nil
+		return
 	}
 
 	semaphore := make(chan struct{}, concurrency)
@@ -416,7 +426,6 @@ func (s *AdaptiveStrategy) processDeviceGroup(ctx context.Context, devices []dev
 	}
 
 	wg.Wait()
-	return nil
 }
 
 func (s *AdaptiveStrategy) collectWithPerformanceTracking(ctx context.Context, dev device.Device) {
@@ -459,18 +468,21 @@ func (s *AdaptiveStrategy) updatePerformanceHistory(deviceID types.DeviceID, lat
 	}
 }
 
+// StrategyManager manages registered scraping strategies and tracks the active one.
 type StrategyManager struct {
 	strategies map[string]ScrapingStrategy
 	current    ScrapingStrategy
 	mutex      sync.RWMutex
 }
 
+// NewStrategyManager creates a new StrategyManager.
 func NewStrategyManager() *StrategyManager {
 	return &StrategyManager{
 		strategies: make(map[string]ScrapingStrategy),
 	}
 }
 
+// RegisterStrategy validates and registers a strategy by name.
 func (sm *StrategyManager) RegisterStrategy(strategy ScrapingStrategy) error {
 	if err := strategy.Validate(); err != nil {
 		return fmt.Errorf("invalid strategy %s: %w", strategy.Name(), err)

--- a/internal/metrics/strategies_test.go
+++ b/internal/metrics/strategies_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sbaerlocher/tsmetrics/pkg/device"
 )
 
+const strategySequential = "sequential"
+
 type mockMetricCollector struct {
 	collectFunc func(ctx context.Context, device device.Device) error
 	callCount   int64
@@ -31,7 +33,7 @@ func (m *mockMetricCollector) getCallCount() int {
 
 func createTestDevices(count int) []device.Device {
 	devices := make([]device.Device, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		devices[i] = device.Device{
 			ID:     types.DeviceID(fmt.Sprintf("device%d", i+1)),
 			Name:   types.DeviceName(fmt.Sprintf("Device %d", i+1)),
@@ -61,7 +63,7 @@ func TestSequentialStrategy_Execute(t *testing.T) {
 
 func TestSequentialStrategy_Timeout(t *testing.T) {
 	collector := &mockMetricCollector{
-		collectFunc: func(ctx context.Context, device device.Device) error {
+		collectFunc: func(ctx context.Context, _ device.Device) error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -136,7 +138,7 @@ func TestParallelStrategy_Execute(t *testing.T) {
 
 func TestParallelStrategy_ConcurrencyLimit(t *testing.T) {
 	collector := &mockMetricCollector{
-		collectFunc: func(ctx context.Context, device device.Device) error {
+		collectFunc: func(_ context.Context, device device.Device) error {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		},
@@ -206,7 +208,7 @@ func TestAdaptiveStrategy_Execute(t *testing.T) {
 
 func TestAdaptiveStrategy_PerformanceTracking(t *testing.T) {
 	collector := &mockMetricCollector{
-		collectFunc: func(ctx context.Context, device device.Device) error {
+		collectFunc: func(_ context.Context, device device.Device) error {
 			if device.ID == types.DeviceID("device2") {
 				return errors.New("simulated error")
 			}
@@ -218,7 +220,7 @@ func TestAdaptiveStrategy_PerformanceTracking(t *testing.T) {
 	devices := createTestDevices(3)
 	ctx := context.Background()
 
-	strategy.Execute(ctx, devices)
+	_ = strategy.Execute(ctx, devices)
 
 	perf, exists := strategy.performanceHist[types.DeviceID("device2")]
 	if !exists {
@@ -250,7 +252,7 @@ func TestStrategyManager_RegisterStrategy(t *testing.T) {
 		t.Errorf("Expected 1 strategy, got %d", len(strategies))
 	}
 
-	if strategies[0] != "sequential" {
+	if strategies[0] != strategySequential {
 		t.Errorf("Expected 'sequential', got %s", strategies[0])
 	}
 }
@@ -260,9 +262,9 @@ func TestStrategyManager_SetActiveStrategy(t *testing.T) {
 	collector := &mockMetricCollector{}
 
 	strategy := NewSequentialStrategy(collector, 10*time.Millisecond, 100*time.Millisecond)
-	manager.RegisterStrategy(strategy)
+	_ = manager.RegisterStrategy(strategy)
 
-	err := manager.SetActiveStrategy("sequential")
+	err := manager.SetActiveStrategy(strategySequential)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -272,7 +274,7 @@ func TestStrategyManager_SetActiveStrategy(t *testing.T) {
 		t.Error("Expected active strategy to be set")
 	}
 
-	if active.Name() != "sequential" {
+	if active.Name() != strategySequential {
 		t.Errorf("Expected 'sequential', got %s", active.Name())
 	}
 }

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -139,7 +139,7 @@ func TestInputValidator_ValidateToken(t *testing.T) {
 		},
 		{
 			name:        "invalid characters",
-			token:       "token-with-@-symbol",
+			token:       "token-with-@-symbol", //nolint:gosec // G101: test data, not a real credential
 			expectError: true,
 		},
 		{

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -97,87 +97,57 @@ func DebugHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
+// healthProbeHandler handles a health probe check with JSON response encoding to prevent XSS.
+func healthProbeHandler(w http.ResponseWriter, r *http.Request, timeout time.Duration, nullStatus, okStatus, errStatus string, checkFn func(ctx context.Context) error) {
+	if healthChecker == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(map[string]string{"status": nullStatus}); err != nil {
+			slog.Error("failed to write health response", "error", err)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	if err := checkFn(ctx); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if encErr := json.NewEncoder(w).Encode(map[string]string{"status": errStatus, "error": err.Error()}); encErr != nil {
+			slog.Error("failed to write health error response", "error", encErr)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": okStatus}); err != nil {
+		slog.Error("failed to write health ok response", "error", err)
+	}
+}
+
 // Kubernetes Health Endpoints
+
 // LivenessHandler provides liveness probe endpoint for Kubernetes.
 func LivenessHandler(w http.ResponseWriter, r *http.Request) {
-	if healthChecker == nil {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
-			slog.Error("failed to write liveness response", "error", err)
-		}
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-	defer cancel()
-
-	err := healthChecker.LivenessCheck(ctx)
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		if _, writeErr := w.Write([]byte(`{"status":"unhealthy","error":"` + err.Error() + `"}`)); writeErr != nil {
-			slog.Error("failed to write liveness error response", "error", writeErr)
-		}
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
-		slog.Error("failed to write liveness ok response", "error", err)
-	}
+	healthProbeHandler(w, r, 5*time.Second, "ok", "ok", "unhealthy", func(ctx context.Context) error {
+		return healthChecker.LivenessCheck(ctx)
+	})
 }
 
+// ReadinessHandler provides readiness probe endpoint for Kubernetes.
 func ReadinessHandler(w http.ResponseWriter, r *http.Request) {
-	if healthChecker == nil {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{"status":"not configured"}`)); err != nil {
-			slog.Error("failed to write readiness not configured response", "error", err)
-		}
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	err := healthChecker.ReadinessCheck(ctx)
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		if _, writeErr := w.Write([]byte(`{"status":"not ready","error":"` + err.Error() + `"}`)); writeErr != nil {
-			slog.Error("failed to write readiness error response", "error", writeErr)
-		}
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(`{"status":"ready"}`)); err != nil {
-		slog.Error("failed to write readiness ok response", "error", err)
-	}
+	healthProbeHandler(w, r, 10*time.Second, "not configured", "ready", "not ready", func(ctx context.Context) error {
+		return healthChecker.ReadinessCheck(ctx)
+	})
 }
 
+// StartupHandler provides startup probe endpoint for Kubernetes.
 func StartupHandler(w http.ResponseWriter, r *http.Request) {
-	if healthChecker == nil {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
-			slog.Error("failed to write startup response", "error", err)
-		}
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-
-	err := healthChecker.StartupCheck(ctx)
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		if _, writeErr := w.Write([]byte(`{"status":"not started","error":"` + err.Error() + `"}`)); writeErr != nil {
-			slog.Error("failed to write startup error response", "error", writeErr)
-		}
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(`{"status":"started"}`)); err != nil {
-		slog.Error("failed to write startup ok response", "error", err)
-	}
+	healthProbeHandler(w, r, 30*time.Second, "ok", "started", "not started", func(ctx context.Context) error {
+		return healthChecker.StartupCheck(ctx)
+	})
 }
 
 func DetailedHealthHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1,13 +1,14 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestEnhancedHealthHandler(t *testing.T) {
-	req, err := http.NewRequest("GET", "/health", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,11 +31,10 @@ func createHTTPServer(addr string, handler http.Handler) *http.Server {
 
 // initializeServerComponents sets up health checker and background scraping
 func initializeServerComponents(cfg config.Config, ctx context.Context, collector *metrics.Collector) {
-	initializeHealthChecker(cfg, collector)
+	initializeHealthChecker()
 	StartBackgroundScraper(cfg, ctx, collector)
 }
 
-// SetupRoutes configures and returns the HTTP routes for the TSMetrics server.
 // SetupRoutes configures and returns the main HTTP router with health and metrics endpoints.
 func SetupRoutes() *http.ServeMux {
 	mux := http.NewServeMux()
@@ -53,7 +52,7 @@ func SetupRoutes() *http.ServeMux {
 }
 
 // initializeHealthChecker sets up the health checker with appropriate components based on configuration
-func initializeHealthChecker(cfg config.Config, collector *metrics.Collector) {
+func initializeHealthChecker() {
 	hc := health.NewHealthChecker()
 
 	// Only register API health checker if API client is available and not using TARGET_DEVICES

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -45,7 +45,7 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 			"note", "auth_key required for tagged devices")
 	}
 
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	tsnetProvider := &metrics.TsnetHTTPClientProvider{
 		Server:  server,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -85,10 +85,10 @@ func setupTestSuite(t *testing.T) *TestSuite {
 		switch r.URL.Path {
 		case "/metrics":
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, "# HELP test_metric Test metric\n# TYPE test_metric counter\ntest_metric 1\n")
+			_, _ = fmt.Fprintf(w, "# HELP test_metric Test metric\n# TYPE test_metric counter\ntest_metric 1\n")
 		case "/health":
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, "OK")
+			_, _ = fmt.Fprintf(w, "OK")
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -537,6 +537,6 @@ func TestPerformanceUnderLoad(t *testing.T) {
 
 func init() {
 	if os.Getenv("INTEGRATION_TESTS") == "" {
-		os.Setenv("INTEGRATION_TESTS", "1")
+		_ = os.Setenv("INTEGRATION_TESTS", "1")
 	}
 }

--- a/tests/load/load_test.go
+++ b/tests/load/load_test.go
@@ -124,7 +124,7 @@ func TestLoad_CacheOperationsUnderStress(t *testing.T) {
 	// Memory monitoring
 	var initialMem, peakMem runtime.MemStats
 	runtime.ReadMemStats(&initialMem)
-	initialMemMB := int64(initialMem.Alloc) / 1024 / 1024
+	initialMemMB := int64(initialMem.Alloc / 1024 / 1024) //nolint:gosec // G115: memory in bytes fits int64
 
 	var operations int64
 	var errors int64
@@ -181,7 +181,7 @@ func TestLoad_CacheOperationsUnderStress(t *testing.T) {
 
 					// Memory check
 					runtime.ReadMemStats(&peakMem)
-					currentMemMB := int64(peakMem.Alloc) / 1024 / 1024
+					currentMemMB := int64(peakMem.Alloc / 1024 / 1024) //nolint:gosec // G115: memory fits int64
 					if currentMemMB > config.MaxMemoryMB {
 						t.Errorf("Memory usage exceeded limit: %d MB > %d MB", currentMemMB, config.MaxMemoryMB)
 						cancel()
@@ -200,8 +200,8 @@ func TestLoad_CacheOperationsUnderStress(t *testing.T) {
 	runtime.GC()
 	var finalMem runtime.MemStats
 	runtime.ReadMemStats(&finalMem)
-	finalMemMB := int64(finalMem.Alloc) / 1024 / 1024
-	peakMemMB := int64(peakMem.Alloc) / 1024 / 1024
+	finalMemMB := int64(finalMem.Alloc / 1024 / 1024) //nolint:gosec // G115: memory in bytes fits int64
+	peakMemMB := int64(peakMem.Alloc / 1024 / 1024)   //nolint:gosec // G115: memory in bytes fits int64
 
 	result := LoadTestResult{
 		TotalOperations:   operations,
@@ -375,7 +375,7 @@ func TestLoad_MemoryLeakDetection(t *testing.T) {
 				case <-ctx.Done():
 					return
 				default:
-					cache.GetDevices(false)
+					_, _ = cache.GetDevices(false)
 					cache.InvalidateDevice(types.DeviceID("device-1"))
 					cache.GetCacheStats()
 					atomic.AddInt64(&operations, 1)
@@ -396,7 +396,7 @@ func TestLoad_MemoryLeakDetection(t *testing.T) {
 				return
 			case <-ticker.C:
 				runtime.ReadMemStats(&peakMem)
-				currentMB := int64(peakMem.Alloc) / 1024 / 1024
+				currentMB := int64(peakMem.Alloc / 1024 / 1024) //nolint:gosec // G115: memory fits int64
 				t.Logf("Current memory usage: %d MB", currentMB)
 			}
 		}
@@ -410,9 +410,9 @@ func TestLoad_MemoryLeakDetection(t *testing.T) {
 	runtime.GC()
 	runtime.ReadMemStats(&finalMem)
 
-	initialMemMB := int64(initialMem.Alloc) / 1024 / 1024
-	peakMemMB := int64(peakMem.Alloc) / 1024 / 1024
-	finalMemMB := int64(finalMem.Alloc) / 1024 / 1024
+	initialMemMB := int64(initialMem.Alloc / 1024 / 1024) //nolint:gosec // G115: memory fits int64
+	peakMemMB := int64(peakMem.Alloc / 1024 / 1024)       //nolint:gosec // G115: memory fits int64
+	finalMemMB := int64(finalMem.Alloc / 1024 / 1024)     //nolint:gosec // G115: memory fits int64
 	leakMB := finalMemMB - initialMemMB
 
 	t.Logf("Memory Leak Detection Results:")


### PR DESCRIPTION
## Summary
- Fix all 44 golangci-lint issues across 19 files (errcheck, noctx, bodyclose, dupl, gosec, unparam, revive, goconst, var-naming)
- Refactor duplicated health probe handlers into shared `healthProbeHandler` with JSON encoding (fixes XSS + dupl)
- Add targeted exclusion rules in `.golangci.yml` with justifications for false positives (G706, G704, G101)

## Test plan
- [x] `golangci-lint run ./...` returns 0 issues
- [x] `go test ./...` all tests pass