### PR TITLE
chore(renovate): disable digest pinning for tsmetrics image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,13 @@
   "extends": [
     "github>sbaerlocher/.github:renovate-go#2026-03-07",
     "github>sbaerlocher/.github:renovate-docker#2026-03-07"
+  ],
+  "packageRules": [
+    {
+      "description": "Disable digest pinning for tsmetrics image (version managed via Chart.appVersion)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/sbaerlocher/tsmetrics"],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Disable digest pinning for `ghcr.io/sbaerlocher/tsmetrics` Docker image
- Version is managed via `Chart.appVersion`, so digest pinning is unnecessary