### PR TITLE
fix(ci): fix security workflow (invalid input + Go version)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,4 +35,3 @@ jobs:
     uses: sbaerlocher/.github/.github/workflows/security-containers.yml@2026-03-07
     with:
       image-ref: "ghcr.io/${{ github.repository }}:latest"
-      scan-type: "registry"


### PR DESCRIPTION
## Summary
- Remove `scan-type: "registry"` from container-scan job — not a valid input in the referenced `security-containers.yml` workflow
- Set `go-version: "1.26"` for CodeQL analysis — `go.mod` requires 1.26.0, shared workflow defaults to 1.25