### PR TITLE
fix(ci): set go-version to 1.26 for CodeQL analysis

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,7 @@ jobs:
     uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-03-07
     with:
       languages: '["go"]'
+      go-version: "1.26"
 
   dependency-scan:
     name: Dependencies & Licenses


### PR DESCRIPTION
## Summary
- Set `go-version: "1.26"` for CodeQL analysis — `go.mod` requires 1.26.0, shared workflow defaults to 1.25