### PR TITLE
refactor: use GitHub Release binary in Dockerfile

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     goarch:
       - amd64
@@ -43,19 +42,6 @@ archives:
       - README.md
       - LICENSE
       - CHANGELOG.md
-  - id: windows
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-    formats:
-      - zip
-    files:
-      - README.md
-      - LICENSE
-      - CHANGELOG.md
 
 checksum:
   name_template: "checksums.txt"
@@ -64,29 +50,7 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^ci:"
-      - "^build:"
-      - "merge conflict"
-      - Merge pull request
-      - Merge remote-tracking branch
-      - Merge branch
-  groups:
-    - title: "New Features"
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
-      order: 0
-    - title: "Bug Fixes"
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
-      order: 1
-    - title: "Performance Improvements"
-      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
-      order: 2
-    - title: "Other Changes"
-      order: 999
+  disable: true
 
 release:
   github:
@@ -96,9 +60,15 @@ release:
   prerelease: auto
   mode: replace
   header: |
-    ## 🚀 TSMetrics {{.Tag}}
+    ## TSMetrics {{.Tag}}
 
-    ### 📦 Installation
+    Tailscale Prometheus Exporter that combines API metadata with live device metrics for complete network observability.
+
+    **Full details**: See [CHANGELOG.md](https://github.com/sbaerlocher/tsmetrics/blob/{{.Tag}}/CHANGELOG.md)
+
+    ---
+
+    ### Installation
 
     **Binary Downloads:**
     Choose the appropriate binary for your platform from the assets below.
@@ -114,9 +84,7 @@ release:
     ```
 
   footer: |
-    **Full Changelog**: https://github.com/sbaerlocher/tsmetrics/compare/{{.PreviousTag}}...{{.Tag}}
-
-    ### 🔐 Verification
+    ### Verification
     ```bash
     sha256sum -c checksums.txt
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-03-08
+
+### Changed
+
+- Replace multi-stage Go build Dockerfile with GitHub Release binary download (distroless base image)
+- Switch from `scratch` to `gcr.io/distroless/static-debian12:nonroot` for better security scanning
+  and built-in nonroot user
+- Remove Windows build targets from GoReleaser (linux and darwin only)
+- Use CHANGELOG.md for release notes instead of auto-generated commit changelog
+- Remove emojis from GoReleaser release template
+
 ## [1.0.2] - 2026-03-07
 
 ### Security
@@ -102,12 +113,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deployment
 
-- Multi-platform support (Linux, macOS, Windows on AMD64/ARM64)
+- Multi-platform support (Linux, macOS on AMD64/ARM64)
 - Container images available at ghcr.io/sbaerlocher/tsmetrics
 - Helm charts for Kubernetes deployment
 - Kustomize overlays for environment-specific configurations
 - Comprehensive health checks and monitoring endpoints
 
+[1.0.3]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.3
 [1.0.2]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.2
 [1.0.1]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.1
 [1.0.0]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,38 @@
-FROM golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS builder
+# ==============================================================================
+# tsmetrics - Dockerfile (GitHub Release Binary)
+# ==============================================================================
 
-# Add build arguments for version info
-ARG VERSION=dev
-ARG BUILD_TIME=unknown
-ARG VERSION_LONG=""
-ARG VERSION_SHORT=""
+# ==============================================================================
+# RELEASE BUILDER STAGE (Download GitHub Release Binary)
+# ==============================================================================
+FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS release-builder
 
-RUN apk update && \
-  apk add --no-cache git~2.52
+ARG TARGETARCH
+ARG VERSION
 
-WORKDIR /src
+RUN apk add --no-cache curl tar ca-certificates && \
+    ARCH=$(case ${TARGETARCH} in \
+    amd64) echo "x86_64" ;; \
+    arm64) echo "arm64" ;; \
+    *) echo ${TARGETARCH} ;; \
+    esac) && \
+    curl -fsSL "https://github.com/sbaerlocher/tsmetrics/releases/download/${VERSION}/tsmetrics_Linux_${ARCH}.tar.gz" -o /tmp/tsmetrics.tar.gz && \
+    tar -xzf /tmp/tsmetrics.tar.gz -C /tmp tsmetrics && \
+    chmod +x /tmp/tsmetrics
 
-COPY .git .git/
+# ==============================================================================
+# PRODUCTION STAGE (GitHub Release Binary)
+# ==============================================================================
+FROM gcr.io/distroless/static-debian12:nonroot AS production
 
-COPY go.mod go.sum ./
-RUN go mod download && go mod verify
-
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux go build \
-  -ldflags="-s -w -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME} -X tailscale.com/version.longStamp=${VERSION_LONG} -X tailscale.com/version.shortStamp=${VERSION_SHORT}" \
-  -buildvcs=true \
-  -buildmode=default \
-  -o /tsmetrics ./cmd/tsmetrics
-
-FROM scratch
-
-# Add OCI metadata labels
 LABEL org.opencontainers.image.title="tsmetrics"
 LABEL org.opencontainers.image.description="A comprehensive Tailscale Prometheus exporter that combines API metadata with live device metrics for complete network observability."
 LABEL org.opencontainers.image.source="https://github.com/sbaerlocher/tsmetrics"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Add ca-certificates for HTTPS calls
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /tsmetrics /tsmetrics
+COPY --from=release-builder --chown=nonroot:nonroot /tmp/tsmetrics /tsmetrics
 
-# Create non-root user
-USER 65534:65534
+USER nonroot:nonroot
 
 EXPOSE 9100
 
@@ -45,4 +40,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
   CMD ["/tsmetrics", "-health-check"]
 
 ENTRYPOINT ["/tsmetrics"]
-CMD []


### PR DESCRIPTION
## Summary
- Replace multi-stage Go build Dockerfile with GitHub Release binary download using distroless base image
- Remove Windows build targets from GoReleaser (linux and darwin only)
- Use CHANGELOG.md for release notes instead of auto-generated commit changelog

## Test plan
- [ ] Verify GoReleaser builds succeed without Windows targets
- [ ] Verify Docker image builds correctly from GitHub Release binary
- [ ] Verify HEALTHCHECK works with `-health-check` flag
- [ ] Confirm distroless image passes security scans