### PR TITLE
fix(security): Wire security middleware and harden HTTP layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,10 @@ func (e *Exporter) scrapeClientMetrics(devices []Device) error {
 - **OAuth Token Security:** Use OAuth2 client credentials flow, handle token refresh
 - **tsnet State:** Secure state directory permissions in production
 - **Network Access:** Restrict scraping to devices with appropriate tags
+- **SSRF:** `ValidateURL` blocks all private/loopback/link-local ranges (not just localhost) — do not weaken this
+- **Rate Limiting:** `getClientID` uses `RemoteAddr` only — never trust X-Forwarded-For/X-Real-IP (forgeable)
+- **Timing Attacks:** `SecureValidateToken` must never `break` early — always iterate all tokens
+- **DevSkim:** Add `// DevSkim: ignore DS162092` on lines that intentionally reference private IPs in security validators
 
 ## Performance Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ tsmetrics_api_requests_total{endpoint}
 - **Development:** `make dev` (live reload via `air` if available)
 - **Testing:** `make test`
 - **Docker:** `make docker-build`, `make docker-run`
+- **Git staging:** `.gitignore` rule `tsmetrics` matches `cmd/tsmetrics/` —
+  use `git add -f cmd/tsmetrics/main.go` for already-tracked files
 
 ### Key Files
 
@@ -132,6 +134,9 @@ tsmetrics_api_requests_total{endpoint}
 - `PORT` — HTTP listen port (default: 9100)
 - `ENV` — `production`/`prod` binds 0.0.0.0, otherwise 127.0.0.1
 - `SCRAPE_INTERVAL` — Device discovery interval (default: 30s)
+- `METRICS_TOKEN` — Bearer token to protect all non-health endpoints (optional; omit to allow unauthenticated access)
+- `RATE_LIMIT_RPS` — Rate limit requests per second (default: 10)
+- `RATE_LIMIT_BURST` — Rate limit burst size (default: 20)
 
 ### Tailscale API Access
 

--- a/cmd/tsmetrics/main.go
+++ b/cmd/tsmetrics/main.go
@@ -136,6 +136,14 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Apply ENV overrides for version metadata before any logging or server setup
+	if v := os.Getenv("VERSION"); v != "" {
+		version = v
+	}
+	if bt := os.Getenv("BUILD_TIME"); bt != "" {
+		buildTime = bt
+	}
+
 	cfg := config.Load()
 
 	setupLogger(cfg)
@@ -153,13 +161,6 @@ func main() {
 		"use_tsnet", cfg.UseTsnet,
 		"log_level", cfg.LogLevel,
 		"log_format", cfg.LogFormat)
-
-	if v := os.Getenv("VERSION"); v != "" {
-		version = v
-	}
-	if bt := os.Getenv("BUILD_TIME"); bt != "" {
-		buildTime = bt
-	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -54,6 +54,20 @@ func NewClient(clientID, clientSecret, tailnet string) *Client {
 	}
 }
 
+// NewClientWithBaseURL creates a client with a fully custom base URL.
+// Intended for use in tests where requests must be directed to an httptest.Server.
+func NewClientWithBaseURL(token, baseURL string) *Client {
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	httpClient.Transport = &tokenTransport{
+		token:     token,
+		transport: http.DefaultTransport,
+	}
+	return &Client{
+		httpClient: httpClient,
+		baseURL:    baseURL,
+	}
+}
+
 // NewClientWithToken creates a new Tailscale API client using a direct OAuth token.
 func NewClientWithToken(token, tailnet string) *Client {
 	httpClient := &http.Client{

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -3,6 +3,7 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -216,8 +217,8 @@ func (ac *APIHealthChecker) CheckHealth(ctx context.Context) error {
 		return fmt.Errorf("API client not initialized")
 	}
 
-	// Try to fetch a minimal amount of data to verify connectivity
-	_, err := ac.client.FetchDevices()
+	// Use a lightweight HEAD request instead of a full device fetch
+	_, err := ac.client.TestConnectivity(ctx)
 	if err != nil {
 		return fmt.Errorf("API connectivity check failed: %w", err)
 	}
@@ -289,41 +290,19 @@ func (pc *PerformanceHealthChecker) CheckHealth(ctx context.Context) error {
 
 // HTTP Response Helpers
 func WriteHealthResponse(w http.ResponseWriter, status HealthStatus, httpStatus int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(httpStatus)
-
-	// Simple JSON encoding without external dependencies
-	jsonResponse := fmt.Sprintf(`{
-		"status": "%s",
-		"timestamp": "%s",
-		"checks": {`, status.Overall, time.Now().UTC().Format(time.RFC3339))
-
-	first := true
-	for name, check := range status.Checks {
-		if !first {
-			jsonResponse += ","
-		}
-		first = false
-
-		lastSuccessStr := "null"
-		if check.LastSuccess != nil {
-			lastSuccessStr = fmt.Sprintf(`"%s"`, check.LastSuccess.Format(time.RFC3339))
-		}
-
-		jsonResponse += fmt.Sprintf(`
-			"%s": {
-				"component": "%s",
-				"status": "%s",
-				"message": "%s",
-				"duration": %d,
-				"timestamp": "%s",
-				"last_success": %s
-			}`, name, check.Component, check.Status, check.Message,
-			check.Duration.Nanoseconds(), check.Timestamp.Format(time.RFC3339), lastSuccessStr)
+	response := struct {
+		Status    Status                 `json:"status"`
+		Timestamp string                 `json:"timestamp"`
+		Checks    map[string]CheckResult `json:"checks"`
+	}{
+		Status:    status.Overall,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Checks:    status.Checks,
 	}
 
-	jsonResponse += "}}"
-	if _, err := w.Write([]byte(jsonResponse)); err != nil {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		slog.Error("failed to write health response", "error", err)
 	}
 }

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -182,18 +182,15 @@ func TestHealthChecker_GetHealthStatus(t *testing.T) {
 }
 
 func TestAPIHealthChecker(t *testing.T) {
-	// Create mock HTTP server
+	// Mock server returns 500 so TestConnectivity reports a failure.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/api/v2/device") {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"devices": []}`))
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-		}
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
-	client := api.NewClientWithToken("test-token", "test-tailnet")
+	// Point the client at the mock server so the health check is self-contained
+	// and does not reach the real Tailscale API.
+	client := api.NewClientWithBaseURL("test-token", server.URL+"/api/v2/tailnet/test-tailnet")
 
 	checker := NewAPIHealthChecker(client)
 
@@ -201,10 +198,9 @@ func TestAPIHealthChecker(t *testing.T) {
 		t.Errorf("Expected component name 'tailscale_api', got %s", checker.ComponentName())
 	}
 
-	// Note: This will fail because we don't have a real API, but it tests the flow
 	err := checker.CheckHealth(context.Background())
 	if err == nil {
-		t.Error("Expected error with mock server, but got none")
+		t.Error("Expected error from mock server returning 500, but got none")
 	}
 
 	// Test with nil client
@@ -290,11 +286,11 @@ func TestWriteHealthResponse(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, `"status": "healthy"`) {
+	if !strings.Contains(body, `"status":"healthy"`) {
 		t.Error("Response should contain status")
 	}
 
-	if !strings.Contains(body, `"test": {`) {
+	if !strings.Contains(body, `"test":{`) {
 		t.Error("Response should contain check results")
 	}
 }

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,7 +90,7 @@ func TestValidateHostname(t *testing.T) {
 		{"empty hostname", "", true},
 		{"newline character", "example\n.com", true},
 		{"carriage return", "example\r.com", true},
-		{"valid long hostname", string(make([]byte, 200)), false},
+		{"valid long hostname", strings.Repeat("a", 200), false},
 	}
 
 	for _, tt := range tests {

--- a/internal/metrics/definitions.go
+++ b/internal/metrics/definitions.go
@@ -2,6 +2,8 @@
 package metrics
 
 import (
+	dto "github.com/prometheus/client_model/go"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -303,6 +305,24 @@ var (
 		[]string{"device_id", "device_name"},
 	)
 )
+
+// GetLastScrapeTime returns the Unix timestamp of the last successful scrape from the Prometheus metric.
+func GetLastScrapeTime() int64 {
+	m := &dto.Metric{}
+	if err := LastScrapeTime.Write(m); err != nil || m.Gauge == nil {
+		return 0
+	}
+	return int64(m.Gauge.GetValue())
+}
+
+// GetOnlineDevicesCount returns the current count of online devices from the Prometheus metric.
+func GetOnlineDevicesCount() int {
+	m := &dto.Metric{}
+	if err := OnlineDevicesCount.Write(m); err != nil || m.Gauge == nil {
+		return 0
+	}
+	return int(m.Gauge.GetValue())
+}
 
 // CleanupDeviceMetrics removes all metrics associated with a specific device.
 func CleanupDeviceMetrics(deviceID string) {

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -370,6 +370,11 @@ func bytesCount(b []byte, c byte) int {
 	return cnt
 }
 
+// validHostnameRe allows only characters that are valid in DNS hostnames and
+// IPv6 literals (brackets and colons). Using an allowlist avoids the risk of
+// missing dangerous characters in a blocklist.
+var validHostnameRe = regexp.MustCompile(`^[a-zA-Z0-9.\-\[\]:]+$`)
+
 func validateHostname(hostname string) error {
 	if hostname == "" {
 		return fmt.Errorf("hostname cannot be empty")
@@ -377,13 +382,8 @@ func validateHostname(hostname string) error {
 	if len(hostname) > 253 {
 		return fmt.Errorf("hostname exceeds maximum length of 253 characters")
 	}
-	// Reject any character that could enable header injection, shell injection, or URL manipulation
-	for _, c := range hostname {
-		if c < 32 || c == ' ' || c == '"' || c == '\'' || c == '`' ||
-			c == '\\' || c == '<' || c == '>' || c == '|' ||
-			c == ';' || c == '&' || c == '$' || c == '#' || c == '?' {
-			return fmt.Errorf("hostname contains invalid character %q", c)
-		}
+	if !validHostnameRe.MatchString(hostname) {
+		return fmt.Errorf("hostname contains invalid characters (only letters, digits, dot, hyphen, and brackets allowed)")
 	}
 	return nil
 }

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -374,8 +374,16 @@ func validateHostname(hostname string) error {
 	if hostname == "" {
 		return fmt.Errorf("hostname cannot be empty")
 	}
-	if strings.Contains(hostname, "\n") || strings.Contains(hostname, "\r") {
-		return fmt.Errorf("hostname contains invalid characters")
+	if len(hostname) > 253 {
+		return fmt.Errorf("hostname exceeds maximum length of 253 characters")
+	}
+	// Reject any character that could enable header injection, shell injection, or URL manipulation
+	for _, c := range hostname {
+		if c < 32 || c == ' ' || c == '"' || c == '\'' || c == '`' ||
+			c == '\\' || c == '<' || c == '>' || c == '|' ||
+			c == ';' || c == '&' || c == '$' || c == '#' || c == '?' {
+			return fmt.Errorf("hostname contains invalid character %q", c)
+		}
 	}
 	return nil
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -52,6 +53,46 @@ func (iv *InputValidator) ValidateString(input string, fieldName string) error {
 	return nil
 }
 
+// privateIPNets contains all private, loopback, and link-local IP ranges.
+var privateIPNets []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"127.0.0.0/8",    // IPv4 loopback
+		"::1/128",        // IPv6 loopback
+		"10.0.0.0/8",     // RFC1918
+		"172.16.0.0/12",  // RFC1918
+		"192.168.0.0/16", // RFC1918
+		"169.254.0.0/16", // link-local (AWS metadata, etc.)
+		"fc00::/7",       // IPv6 unique local
+		"fe80::/10",      // IPv6 link-local
+	} {
+		_, network, _ := net.ParseCIDR(cidr)
+		privateIPNets = append(privateIPNets, network)
+	}
+}
+
+func isPrivateHost(hostname string) bool {
+	if strings.EqualFold(hostname, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		return false
+	}
+	// Normalize IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) to plain IPv4
+	// so it matches the 4-byte IPv4 ranges in privateIPNets.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	for _, network := range privateIPNets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 func (iv *InputValidator) ValidateURL(input string, fieldName string) error {
 	if err := iv.ValidateString(input, fieldName); err != nil {
 		return err
@@ -67,10 +108,12 @@ func (iv *InputValidator) ValidateURL(input string, fieldName string) error {
 		return fmt.Errorf("field %s must use http or https scheme", fieldName)
 	}
 
-	// Prevent localhost/private network access unless explicitly allowed
-	hostname := parsedURL.Hostname()
-	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" { // DevSkim: ignore DS162092 - Security validation intentionally blocks localhost
-		return fmt.Errorf("field %s cannot reference localhost", fieldName)
+	// Prevent access to localhost and all private/reserved IP ranges (SSRF protection).
+	// NOTE: This checks the literal hostname only — DNS rebinding is not prevented here.
+	// A hostname that resolves to a private IP at request time would bypass this check.
+	// Callers that need full SSRF protection must use a custom dialer with post-DNS IP validation.
+	if isPrivateHost(parsedURL.Hostname()) { // DevSkim: ignore DS162092 - Security validation intentionally blocks private hosts
+		return fmt.Errorf("field %s cannot reference private or reserved addresses", fieldName)
 	}
 
 	return nil
@@ -203,26 +246,17 @@ func RateLimitMiddleware(limiter *RateLimiter) func(http.Handler) http.Handler {
 }
 
 func getClientID(r *http.Request) string {
-	// Try to get real IP from various headers
-	ip := r.Header.Get("X-Forwarded-For")
-	if ip == "" {
-		ip = r.Header.Get("X-Real-IP")
-	}
-	if ip == "" {
-		ip = r.RemoteAddr
-	}
+	// Always use RemoteAddr — never trust X-Forwarded-For or X-Real-IP,
+	// as these can be forged by clients to bypass rate limiting.
+	ip := r.RemoteAddr
 
-	// Extract IP from "IP:Port" format
-	if colonIndex := strings.LastIndex(ip, ":"); colonIndex != -1 {
-		ip = ip[:colonIndex]
+	// Strip port from "IP:Port" or "[IPv6]:Port" format
+	host, _, err := net.SplitHostPort(ip)
+	if err != nil {
+		// No port present or unparseable — use as-is
+		return ip
 	}
-
-	// Remove any additional forwarded IPs (take first one)
-	if commaIndex := strings.Index(ip, ","); commaIndex != -1 {
-		ip = strings.TrimSpace(ip[:commaIndex])
-	}
-
-	return ip
+	return host
 }
 
 // Authentication Utilities
@@ -251,23 +285,21 @@ func (av *AuthValidator) RemoveToken(token string) {
 	delete(av.validTokens, token)
 }
 
-func (av *AuthValidator) ValidateToken(token string) bool {
-	av.mutex.RLock()
-	defer av.mutex.RUnlock()
-	return av.validTokens[token]
-}
-
-// Secure token comparison to prevent timing attacks
+// SecureValidateToken uses constant-time comparison against all tokens.
+// The loop never breaks early so the number of remaining iterations cannot
+// be used as a timing oracle to enumerate valid tokens.
+// NOTE: Total execution time still scales linearly with the number of stored tokens,
+// so an attacker making many requests could infer how many tokens are configured.
+// For the typical single-token deployment this is not exploitable.
 func (av *AuthValidator) SecureValidateToken(token string) bool {
 	av.mutex.RLock()
 	defer av.mutex.RUnlock()
 
 	isValid := false
 	for validToken := range av.validTokens {
-		// Use constant-time comparison
 		if subtle.ConstantTimeCompare([]byte(token), []byte(validToken)) == 1 {
 			isValid = true
-			break
+			// no break — always iterate all tokens to prevent timing side-channel
 		}
 	}
 

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -58,11 +58,13 @@ var privateIPNets []*net.IPNet
 
 func init() {
 	for _, cidr := range []string{
+		"0.0.0.0/8",      // current network (RFC 1122)
 		"127.0.0.0/8",    // IPv4 loopback
 		"::1/128",        // IPv6 loopback
 		"10.0.0.0/8",     // RFC1918
 		"172.16.0.0/12",  // RFC1918
 		"192.168.0.0/16", // RFC1918
+		"100.64.0.0/10",  // CGNAT / Tailscale device IPs (RFC 6598)
 		"169.254.0.0/16", // link-local (AWS metadata, etc.)
 		"fc00::/7",       // IPv6 unique local
 		"fe80::/10",      // IPv6 link-local
@@ -202,7 +204,7 @@ func (rl *RateLimiter) Cleanup() {
 
 	for clientID, limiter := range rl.limiters {
 		// Remove limiters that haven't been used recently
-		if limiter.Tokens() == float64(rl.burst) {
+		if limiter.Tokens() >= float64(rl.burst) {
 			delete(rl.limiters, clientID)
 		}
 	}
@@ -310,10 +312,12 @@ func (av *AuthValidator) SecureValidateToken(token string) bool {
 func AuthenticationMiddleware(validator *AuthValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip authentication for health checks
+			// Skip authentication for health/probe endpoints
 			if strings.HasPrefix(r.URL.Path, "/health") ||
 				strings.HasPrefix(r.URL.Path, "/livez") ||
-				strings.HasPrefix(r.URL.Path, "/readyz") {
+				strings.HasPrefix(r.URL.Path, "/readyz") ||
+				strings.HasPrefix(r.URL.Path, "/startupz") ||
+				strings.HasPrefix(r.URL.Path, "/healthz") {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -80,6 +80,12 @@ func isPrivateHost(hostname string) bool {
 	}
 	ip := net.ParseIP(hostname)
 	if ip == nil {
+		// hostname is a DNS name, not an IP literal — we cannot check it here.
+		// DNS-rebinding (a name resolving to a private IP at request time) is
+		// documented as out-of-scope; callers that need full protection must use
+		// a custom dialer with post-DNS IP validation.
+		// In this project, device hostnames originate exclusively from the
+		// authenticated Tailscale API, so they are treated as trusted input.
 		return false
 	}
 	// Normalize IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) to plain IPv4
@@ -312,12 +318,15 @@ func (av *AuthValidator) SecureValidateToken(token string) bool {
 func AuthenticationMiddleware(validator *AuthValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip authentication for health/probe endpoints
-			if strings.HasPrefix(r.URL.Path, "/health") ||
-				strings.HasPrefix(r.URL.Path, "/livez") ||
-				strings.HasPrefix(r.URL.Path, "/readyz") ||
-				strings.HasPrefix(r.URL.Path, "/startupz") ||
-				strings.HasPrefix(r.URL.Path, "/healthz") {
+			// Skip authentication for health/probe endpoints.
+			// Exact-match or explicit sub-path prefix to avoid accidentally
+			// whitelisting future routes like /health-admin.
+			p := r.URL.Path
+			if p == "/health" || strings.HasPrefix(p, "/health/") ||
+				p == "/healthz" || strings.HasPrefix(p, "/healthz/") ||
+				p == "/livez" || strings.HasPrefix(p, "/livez/") ||
+				p == "/readyz" || strings.HasPrefix(p, "/readyz/") ||
+				p == "/startupz" || strings.HasPrefix(p, "/startupz/") {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -450,16 +450,18 @@ func TestGetClientID(t *testing.T) {
 			expectedIP: "192.168.1.1",
 		},
 		{
-			name:          "x-forwarded-for header",
+			// X-Forwarded-For is ignored — RemoteAddr is the only trusted source
+			name:          "x-forwarded-for header ignored",
 			remoteAddr:    "10.0.0.1:12345",
 			xForwardedFor: "192.168.1.1, 10.0.0.2",
-			expectedIP:    "192.168.1.1",
+			expectedIP:    "10.0.0.1",
 		},
 		{
-			name:       "x-real-ip header",
+			// X-Real-IP is ignored — RemoteAddr is the only trusted source
+			name:       "x-real-ip header ignored",
 			remoteAddr: "10.0.0.1:12345",
 			xRealIP:    "192.168.1.1",
-			expectedIP: "192.168.1.1",
+			expectedIP: "10.0.0.1",
 		},
 	}
 

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -310,23 +310,18 @@ func TestAuthValidator(t *testing.T) {
 	validator.AddValidToken(token)
 
 	// Valid token should be accepted
-	if !validator.ValidateToken(token) {
+	if !validator.SecureValidateToken(token) {
 		t.Error("Valid token should be accepted")
 	}
 
 	// Invalid token should be rejected
-	if validator.ValidateToken("invalid-token") {
+	if validator.SecureValidateToken("invalid-token") {
 		t.Error("Invalid token should be rejected")
-	}
-
-	// Test secure validation
-	if !validator.SecureValidateToken(token) {
-		t.Error("Valid token should be accepted by secure validation")
 	}
 
 	// Remove token
 	validator.RemoveToken(token)
-	if validator.ValidateToken(token) {
+	if validator.SecureValidateToken(token) {
 		t.Error("Removed token should be rejected")
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -115,9 +115,10 @@ func healthProbeHandler(w http.ResponseWriter, r *http.Request, timeout time.Dur
 	defer cancel()
 
 	if err := checkFn(ctx); err != nil {
+		slog.Warn("health probe check failed", "probe", errStatus, "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
-		if encErr := json.NewEncoder(w).Encode(map[string]string{"status": errStatus, "error": err.Error()}); encErr != nil {
+		if encErr := json.NewEncoder(w).Encode(map[string]string{"status": errStatus}); encErr != nil {
 			slog.Error("failed to write health error response", "error", encErr)
 		}
 		return

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sbaerlocher/tsmetrics/internal/api"
 	"github.com/sbaerlocher/tsmetrics/internal/health"
+	"github.com/sbaerlocher/tsmetrics/internal/metrics"
 )
 
 var (
@@ -37,16 +38,18 @@ func EnhancedHealthHandler(w http.ResponseWriter, _ *http.Request) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 
+	lastScrape := getLastScrapeTime()
 	status := map[string]interface{}{
-		"status":         "ok",
-		"version":        version,
-		"build_time":     buildTime,
-		"timestamp":      time.Now().Unix(),
-		"memory_mb":      bToMb(m.Alloc),
-		"goroutines":     runtime.NumGoroutine(),
-		"last_scrape":    getLastScrapeTime(),
-		"devices_online": getOnlineDeviceCount(),
-		"uptime_seconds": getUptimeSeconds(),
+		"status":                "ok",
+		"version":               version,
+		"build_time":            buildTime,
+		"timestamp":             time.Now().Unix(),
+		"memory_mb":             bToMb(m.Alloc),
+		"goroutines":            runtime.NumGoroutine(),
+		"last_scrape":           lastScrape,
+		"first_scrape_complete": lastScrape != 0,
+		"devices_online":        getOnlineDeviceCount(),
+		"uptime_seconds":        getUptimeSeconds(),
 	}
 
 	if tailnet := os.Getenv("TAILNET_NAME"); tailnet != "" {
@@ -66,8 +69,8 @@ func EnhancedHealthHandler(w http.ResponseWriter, _ *http.Request) {
 
 			_, err := apiClient.TestConnectivity(ctx)
 			if err != nil {
+				slog.Warn("API connectivity check failed", "error", err)
 				status["api_status"] = "degraded"
-				status["api_error"] = err.Error()
 			} else {
 				status["api_status"] = "healthy"
 			}
@@ -177,9 +180,9 @@ func getUptimeSeconds() int64 {
 }
 
 func getLastScrapeTime() int64 {
-	return time.Now().Unix() - 30
+	return metrics.GetLastScrapeTime()
 }
 
 func getOnlineDeviceCount() int {
-	return 5
+	return metrics.GetOnlineDevicesCount()
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -66,10 +66,10 @@ func TestUtilityFunctions(t *testing.T) {
 		t.Error("Expected non-negative uptime")
 	}
 
-	// Test getLastScrapeTime
+	// Test getLastScrapeTime — returns 0 before the first scrape completes
 	lastScrape := getLastScrapeTime()
-	if lastScrape <= 0 {
-		t.Error("Expected positive last scrape time")
+	if lastScrape < 0 {
+		t.Error("Expected non-negative last scrape time")
 	}
 
 	// Test getOnlineDeviceCount

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -88,8 +88,8 @@ func applySecurityMiddleware(ctx context.Context, handler http.Handler) http.Han
 	h := security.RateLimitMiddleware(rateLimiter)(handler)
 
 	// Token auth is opt-in: set METRICS_TOKEN to require a Bearer token on all
-	// non-health endpoints. AuthenticationMiddleware already whitelists /livez,
-	// /readyz, /startupz, and /health so probes always pass.
+	// non-probe endpoints. AuthenticationMiddleware whitelists /health, /healthz,
+	// /livez, /readyz, and /startupz so Kubernetes probes always pass.
 	if token := os.Getenv("METRICS_TOKEN"); token != "" {
 		validator := security.NewAuthValidator()
 		validator.AddValidToken(token)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/sbaerlocher/tsmetrics/internal/config"
 	"github.com/sbaerlocher/tsmetrics/internal/health"
 	"github.com/sbaerlocher/tsmetrics/internal/metrics"
+	"github.com/sbaerlocher/tsmetrics/internal/security"
 )
 
 // createHTTPServer creates a configured HTTP server with standard timeouts.
@@ -49,6 +51,53 @@ func SetupRoutes() *http.ServeMux {
 	mux.HandleFunc("/healthz", DetailedHealthHandler)
 
 	return mux
+}
+
+// applySecurityMiddleware wraps the handler with rate limiting, optional token auth,
+// and security headers. A background goroutine cleans up idle rate-limiter entries
+// every 5 minutes for the lifetime of ctx.
+func applySecurityMiddleware(ctx context.Context, handler http.Handler) http.Handler {
+	rps := 10.0
+	if v := os.Getenv("RATE_LIMIT_RPS"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			rps = f
+		}
+	}
+	burst := 20
+	if v := os.Getenv("RATE_LIMIT_BURST"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			burst = n
+		}
+	}
+	rateLimiter := security.NewRateLimiter(rps, burst)
+
+	// Cleanup idle per-IP limiters to prevent unbounded map growth (VULN-002)
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				rateLimiter.Cleanup()
+			}
+		}
+	}()
+
+	h := security.RateLimitMiddleware(rateLimiter)(handler)
+
+	// Token auth is opt-in: set METRICS_TOKEN to require a Bearer token on all
+	// non-health endpoints. AuthenticationMiddleware already whitelists /livez,
+	// /readyz, /startupz, and /health so probes always pass.
+	if token := os.Getenv("METRICS_TOKEN"); token != "" {
+		validator := security.NewAuthValidator()
+		validator.AddValidToken(token)
+		h = security.AuthenticationMiddleware(validator)(h)
+		slog.Info("metrics endpoint protected with bearer token authentication")
+	}
+
+	return security.SecurityHeadersMiddleware(h)
 }
 
 // initializeHealthChecker sets up the health checker with appropriate components based on configuration
@@ -92,7 +141,7 @@ func RunStandalone(cfg config.Config, ctx context.Context, collector *metrics.Co
 	slog.Info("HTTP client configured", "network", "standard")
 
 	mux := SetupRoutes()
-	srv := createHTTPServer(addr, mux)
+	srv := createHTTPServer(addr, applySecurityMiddleware(ctx, mux))
 
 	// Initialize health checker and background scraper
 	initializeServerComponents(cfg, ctx, collector)

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -63,12 +63,14 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 	}
 
 	mux := SetupRoutes()
-	tsHTTPServer := createHTTPServer("", mux) // No Addr for tsnet server
-	tsHTTPServer.Addr = ""                    // Clear Addr for tsnet
+	handler := applySecurityMiddleware(ctx, mux)
+
+	tsHTTPServer := createHTTPServer("", handler) // No Addr for tsnet server
+	tsHTTPServer.Addr = ""                        // Clear Addr for tsnet
 
 	host := getLocalBindHost()
 	localAddr := fmt.Sprintf("%s:%s", host, cfg.Port)
-	localHTTPServer := createHTTPServer(localAddr, mux)
+	localHTTPServer := createHTTPServer(localAddr, handler)
 
 	// Initialize health checker and background scraper
 	initializeServerComponents(cfg, ctx, collector)


### PR DESCRIPTION
The `internal/security` package contained fully-implemented middleware for
rate limiting, Bearer token authentication, and security headers — but none
of it was wired into the HTTP server. Every endpoint, including `/metrics`
(which exposes user email addresses, device names, and full Tailnet topology),
was publicly accessible with zero controls applied.

This PR activates the existing security infrastructure and closes the
remaining gaps identified in a security review.

## What changed

**Middleware now applied on every request** (`server.go`, `tsnet.go`)
Both server modes (standalone and tsnet) now go through
`SecurityHeadersMiddleware → RateLimitMiddleware → AuthenticationMiddleware`.
Token auth is opt-in via `METRICS_TOKEN` env var; health probe endpoints
(`/livez`, `/readyz`, `/startupz`, `/health`) are always whitelisted.

**Rate limiter memory leak fixed** (`server.go`)
A background goroutine now calls `Cleanup()` every 5 minutes for the
lifetime of the server context, preventing the per-IP limiter map from
growing without bound. Rate limits are configurable via `RATE_LIMIT_RPS`
and `RATE_LIMIT_BURST` (defaults: 10 req/s, burst 20).

**Timing-unsafe `ValidateToken` removed** (`security.go`, `security_test.go`)
The non-constant-time map lookup was exported alongside `SecureValidateToken`,
making it easy to accidentally reach for the wrong one. `ValidateToken` is
gone; `SecureValidateToken` is the only path. The loop no longer breaks
early, closing a timing oracle that could enumerate valid tokens.

**`getClientID` hardened** (`security.go`)
Was reading `X-Forwarded-For` / `X-Real-IP` for rate-limiting identity.
These headers are attacker-controlled and trivially forgeable. Now uses
`net.SplitHostPort(r.RemoteAddr)` only, which also correctly handles IPv6
addresses (the previous `strings.LastIndex` approach mangled them).

**SSRF protection extended** (`security.go`)
`ValidateURL` previously only blocked `localhost`, `127.0.0.1`, and `::1`.
It now blocks all RFC 1918, loopback, and link-local ranges via
`isPrivateHost`. A DNS-rebinding limitation is documented in-code.

**`validateHostname` injection hardening** (`scraper.go`)
Now rejects shell metacharacters, header injection chars, and URL
manipulation characters in addition to the previous newline-only check.
Length is capped at 253 characters (DNS max).

**Internal error details removed from `/health`** (`handlers.go`)
Raw `err.Error()` from Tailscale API failures was written into the JSON
response body. It is now logged server-side only.

**Manual JSON building replaced** (`checker.go`)
`WriteHealthResponse` was constructing JSON via `fmt.Sprintf` with
`check.Message` interpolated directly. Special characters in error
messages could produce malformed JSON. Replaced with `json.NewEncoder`.

**Hardcoded placeholder values fixed** (`handlers.go`, `definitions.go`)
`getLastScrapeTime()` returned `time.Now() - 30s` and `getOnlineDeviceCount()`
returned `5` regardless of reality. Both now read from the actual Prometheus
gauges. A `first_scrape_complete` boolean is added to the `/health` response
so consumers can distinguish zero online devices from not-yet-scraped state.