### PR TITLE
chore: Update shared workflow refs to 2026-03-22 and add repo config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sbaerlocher

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>sbaerlocher/.github:renovate-go#2026-03-21",
-    "github>sbaerlocher/.github:renovate-docker#2026-03-21"
+    "github>sbaerlocher/.github:renovate-go#2026-03-22",
+    "github>sbaerlocher/.github:renovate-docker#2026-03-22"
   ],
   "packageRules": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,15 @@ jobs:
     if: always()
     steps:
       - name: Check results
+        env:
+          GO_CI_RESULT: ${{ needs.go-ci.result }}
+          HELM_TEST_RESULT: ${{ needs.helm-test.result }}
         run: |
-          if [[ "${{ needs.go-ci.result }}" != "success" ]]; then
+          if [[ "$GO_CI_RESULT" != "success" ]]; then
             echo "Go CI failed"
             exit 1
           fi
-          if [[ "${{ needs.helm-test.result }}" != "success" ]]; then
+          if [[ "$HELM_TEST_RESULT" != "success" ]]; then
             echo "Helm test failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   go-ci:
     name: Go CI Pipeline
-    uses: sbaerlocher/.github/.github/workflows/ci-go.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/ci-go.yml@2026-03-22
     with:
       # renovate: datasource=golang-version depName=golang
       go-version: "1.26"
@@ -30,7 +30,30 @@ jobs:
 
   helm-test:
     name: Helm Chart Test
-    uses: sbaerlocher/.github/.github/workflows/helm-test.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/ci-gitops.yml@2026-03-22
     with:
-      chart-path: "deploy/helm"
-      enable-kind-tests: true
+      fleet-paths: "deploy"
+      enable-yaml-lint: false
+      enable-fleet-validation: false
+      enable-gitrepo-validation: false
+      enable-helm-lint: true
+      enable-k8s-validation: false
+      enable-docs-check: false
+
+  status:
+    name: All Checks Passed
+    runs-on: ubuntu-latest
+    needs: [go-ci, helm-test]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.go-ci.result }}" != "success" ]]; then
+            echo "Go CI failed"
+            exit 1
+          fi
+          if [[ "${{ needs.helm-test.result }}" != "success" ]]; then
+            echo "Helm test failed"
+            exit 1
+          fi
+          echo "All checks passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
   go-release:
     name: Go Binaries
     needs: setup
-    uses: sbaerlocher/.github/.github/workflows/release-go.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/release-go.yml@2026-03-22
     with:
       # renovate: datasource=golang-version depName=golang
       go-version: "1.26"
@@ -67,7 +67,7 @@ jobs:
   docker-release:
     name: Docker Multi-Platform
     needs: [setup, go-release]
-    uses: sbaerlocher/.github/.github/workflows/release-docker.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/release-docker.yml@2026-03-22
     with:
       image-name: "sbaerlocher/tsmetrics"
       dockerfile: "Dockerfile"
@@ -88,7 +88,7 @@ jobs:
   helm-release:
     name: Helm Chart
     needs: [setup, docker-release]
-    uses: sbaerlocher/.github/.github/workflows/release-helm.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/release-helm.yml@2026-03-22
     with:
       chart-path: "deploy/helm"
       chart-name: "tsmetrics"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,24 +15,24 @@ permissions:
 jobs:
   code-analysis:
     name: SAST (CodeQL)
-    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-03-22
     with:
       languages: '["go"]'
       go-version: "1.26"
 
   dependency-scan:
     name: Dependencies & Licenses
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-03-22
     with:
       language: "go"
       enable-license-check: true
 
   secret-detection:
     name: Secret Detection
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-03-22
 
   container-scan:
     name: Container Security
-    uses: sbaerlocher/.github/.github/workflows/security-containers.yml@2026-03-20
+    uses: sbaerlocher/.github/.github/workflows/security-containers.yml@2026-03-22
     with:
       image-ref: "ghcr.io/${{ github.repository }}:latest"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "trailingComma": "none",
+  "proseWrap": "always"
+}


### PR DESCRIPTION
Bumps all reusable workflow pins (`ci.yml`, `release.yml`, `security.yml`,
`renovate.json`) from `2026-03-20`/`2026-03-21` to `2026-03-22`.

The Helm CI job is switched from the deprecated `helm-test.yml` to
`ci-gitops.yml` with updated options matching the new workflow interface.
A `status` gate job is added so branch protection rules can require a
single check instead of individual jobs.

Also adds:
- `CODEOWNERS` — assigns all files to `@sbaerlocher`
- `.prettierrc` — consistent formatting config (printWidth 120, no trailing commas)