### PR TITLE
chore(release): Prepare v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.4] - 2026-03-22
 
 ### Security
 
@@ -171,7 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kustomize overlays for environment-specific configurations
 - Comprehensive health checks and monitoring endpoints
 
-[Unreleased]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.3...HEAD
+[1.0.4]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.3
 [1.0.2]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.2
 [1.0.1]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.1


### PR DESCRIPTION
Finalizes the CHANGELOG for the v1.0.4 release:

- Renames `[Unreleased]` → `[1.0.4] - 2026-03-22`
- Updates the compare link to `v1.0.3...v1.0.4`

After merging this PR, tag `v1.0.4` on main to trigger the GoReleaser workflow.