### PR TITLE
fix(deps): Fix invalid JSON escape in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     {
       "description": "Track tsmetrics appVersion in Helm Chart.yaml",
       "customType": "regex",
-      "managerFilePatterns": ["/^deploy/helm/Chart\.yaml$/"],
+      "managerFilePatterns": ["/^deploy/helm/Chart\\.yaml$/"],
       "matchStrings": ["appVersion: \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "ghcr.io/sbaerlocher/tsmetrics",
       "datasourceTemplate": "docker",


### PR DESCRIPTION
## Summary

- Fix `\.` → `\\.` in `managerFilePatterns` regex — `\.` is not a valid JSON escape sequence
- Renovate was falling back to JSON5 parsing and logging warnings about future deprecation

## Test plan

- [x] `python3 -c "import json; json.load(open('.github/renovate.json'))"` passes
- [ ] Renovate log no longer shows "File contents are invalid JSONC" warning