### PR TITLE
chore(release): Prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.1.0] - 2026-04-04
 
 ### Added
@@ -219,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kustomize overlays for environment-specific configurations
 - Comprehensive health checks and monitoring endpoints
 
+[1.1.0]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.3
 [1.0.2]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-04-04
 
 ### Added
 
@@ -39,11 +39,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `readOnlyRootFilesystem: true`)
 - Delete orphaned `pvc.yaml` from production overlay
 - Pin Kustomize image tags to `v1.0.4` instead of `latest`
+- Remove dead code: `runtime.ReadMemStats`, `bToMb`, `getOnlineDeviceCount` and
+  unused `runtime` import from health handler
+- Fix `truncateLabel` to slice by runes instead of bytes (UTF-8 safety)
 
 ### Changed
 
 - Kustomize production overlay: replaced PVC volume mount with `TSNET_STATE_SECRET` env var
 - Helm default `storage.type` changed from `pvc` to `k8s-secret`
+- Downgrade kube store internal log level from Info to Debug (noisy Tailscale library logs)
+
+### Dependencies
+
+- Bump `tailscale.com` to v1.96.5
 
 ## [1.0.4] - 2026-03-22
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -43,10 +43,10 @@ annotations:
       --set tailscale.tailnetName=your-company
     ```
   artifacthub.io/changes: |
-    - Initial release with OCI support
-    - Health checks and probes
-    - ServiceMonitor for Prometheus Operator
-    - Persistence for tsnet state
+    - Kubernetes Secret as tsnet state backend (replaces PVC)
+    - RBAC resources (ServiceAccount, Role, RoleBinding)
+    - Security hardening (label truncation, response limits, health endpoint)
+    - Helm Secret name and key alignment fixes
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/sbaerlocher/tsmetrics/tree/main/deploy/helm/tsmetrics

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: tsmetrics
 description: A Helm chart for tsmetrics - Tailscale Prometheus Exporter
 type: application
-version: 0.2.0
-appVersion: "0.1.7"
+version: 0.3.0
+appVersion: "1.1.0"
 keywords:
   - tailscale
   - prometheus

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -19,7 +19,7 @@ resources:
 
 images:
   - name: ghcr.io/sbaerlocher/tsmetrics
-    newTag: v1.0.4
+    newTag: v1.1.0
 
 labels:
   - pairs:

--- a/deploy/kustomize/overlays/production/kustomization.yaml
+++ b/deploy/kustomize/overlays/production/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
 
 images:
   - name: ghcr.io/sbaerlocher/tsmetrics
-    newTag: v1.0.4
+    newTag: v1.1.0
 
 replicas:
   - name: tsmetrics


### PR DESCRIPTION
## Summary

- Set CHANGELOG version to `[1.1.0] - 2026-04-04`
- Bump Helm chart `appVersion` to `1.1.0`, chart `version` to `0.3.0`
- Update Kustomize image tags to `v1.1.0` (base + production)

## Test plan

- [ ] CI passes
- [ ] Merge triggers release workflow creating `v1.1.0` tag