### PR TITLE
fix(storage): Register kubestore provider for kube: prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-04-04
+
+### Fixed
+
+- Register `kubestore` provider via blank import (`_ "tailscale.com/ipn/store/kubestore"`)
+  so `store.New("kube:...")` recognizes the `kube:` prefix at runtime
+
 ## [1.1.0] - 2026-04-04
 
 ### Added
@@ -221,6 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kustomize overlays for environment-specific configurations
 - Comprehensive health checks and monitoring endpoints
 
+[1.1.1]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/sbaerlocher/tsmetrics/releases/tag/v1.0.3

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: tsmetrics
 description: A Helm chart for tsmetrics - Tailscale Prometheus Exporter
 type: application
-version: 0.3.0
-appVersion: "1.1.0"
+version: 0.3.1
+appVersion: "1.1.1"
 keywords:
   - tailscale
   - prometheus

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -19,7 +19,7 @@ resources:
 
 images:
   - name: ghcr.io/sbaerlocher/tsmetrics
-    newTag: v1.1.0
+    newTag: v1.1.1
 
 labels:
   - pairs:

--- a/deploy/kustomize/overlays/production/kustomization.yaml
+++ b/deploy/kustomize/overlays/production/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
 
 images:
   - name: ghcr.io/sbaerlocher/tsmetrics
-    newTag: v1.1.0
+    newTag: v1.1.1
 
 replicas:
   - name: tsmetrics

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"tailscale.com/ipn/store"
+	_ "tailscale.com/ipn/store/kubestore" // Register "kube:" state store provider
 	"tailscale.com/tsnet"
 
 	"github.com/sbaerlocher/tsmetrics/internal/config"


### PR DESCRIPTION
## Summary

- Add blank import `_ "tailscale.com/ipn/store/kubestore"` to register the `kube:` state store provider
- Without this, `store.New("kube:...")` fails at runtime because no provider handles the `kube:` prefix
- Prepares release v1.1.1

## Test plan

- [x] `go build ./...` passes
- [ ] Deploy with `TSNET_STATE_SECRET` and verify kube store initializes without error