### PR TITLE
fix(deploy): Set HOME=/tmp for nonroot distroless container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-04-04
+
+### Fixed
+
+- Set `HOME=/tmp` in Kubernetes deployments to fix `mkdir /nonexistent: read-only file system`
+  crash when tsnet runs as nonroot user (65534) in distroless container
+
 ## [1.1.2] - 2026-04-04
 
 ### Fixed
@@ -235,6 +242,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kustomize overlays for environment-specific configurations
 - Comprehensive health checks and monitoring endpoints
 
+[1.1.3]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/sbaerlocher/tsmetrics/compare/v1.0.4...v1.1.0

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: tsmetrics
 description: A Helm chart for tsmetrics - Tailscale Prometheus Exporter
 type: application
-version: 0.3.2
-appVersion: "1.1.2"
+version: 0.3.3
+appVersion: "1.1.3"
 keywords:
   - tailscale
   - prometheus
@@ -43,7 +43,7 @@ annotations:
       --set tailscale.tailnetName=your-company
     ```
   artifacthub.io/changes: |
-    - Fix missing server.Close() on early-return error paths in tsnet init
+    - Fix read-only filesystem crash by setting HOME=/tmp for nonroot distroless
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/sbaerlocher/tsmetrics/tree/main/deploy/helm/tsmetrics

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -101,6 +101,8 @@ spec:
               containerPort: {{ .Values.config.port }}
               protocol: TCP
           env:
+            - name: HOME
+              value: /tmp
             - name: PORT
               value: {{ .Values.config.port | quote }}
             - name: ENV

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -62,6 +62,8 @@ spec:
               containerPort: 9100
               protocol: TCP
           env:
+            - name: HOME
+              value: /tmp
             - name: PORT
               value: "9100"
             - name: ENV

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -19,7 +19,7 @@ resources:
 
 images:
   - name: ghcr.io/sbaerlocher/tsmetrics
-    newTag: v1.1.2
+    newTag: v1.1.3
 
 labels:
   - pairs:

--- a/deploy/kustomize/overlays/production/kustomization.yaml
+++ b/deploy/kustomize/overlays/production/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
 
 images:
   - name: ghcr.io/sbaerlocher/tsmetrics
-    newTag: v1.1.2
+    newTag: v1.1.3
 
 replicas:
   - name: tsmetrics


### PR DESCRIPTION
## Summary
- Fix CrashLoopBackOff: `mkdir /nonexistent: read-only file system`
- tsnet writes to `$HOME` which defaults to `/nonexistent` for user 65534 in distroless
- Set `HOME=/tmp` env var in both Helm and Kustomize deployments
- Bump to v1.1.3

## Test plan
- [ ] Verify pod starts without `read-only file system` error
- [ ] Verify tsnet connects and serves metrics