### PR TITLE
fix(metrics): prefer MagicDNS FQDN over OS hostname for scrape URL

### DIFF
--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -103,6 +103,32 @@ func TestValidateHostname(t *testing.T) {
 	}
 }
 
+func TestScrapeHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		devName  string
+		devHost  string
+		expected string
+	}{
+		{"FQDN preferred when both set", "device.tail1234.ts.net", "device", "device.tail1234.ts.net"},
+		{"falls back to Host when Name empty", "", "device", "device"},
+		{"returns empty when both empty", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev := device.Device{
+				Name: types.DeviceName(tt.devName),
+				Host: tt.devHost,
+			}
+			got := scrapeHost(dev)
+			if got != tt.expected {
+				t.Errorf("scrapeHost() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestParseLabels(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -184,21 +184,25 @@ func scrapeClient(dev device.Device, client *http.Client, cfg config.Config) err
 	return parseMetricsResponse(dev, io.LimitReader(resp.Body, 10*1024*1024))
 }
 
-func buildMetricsURL(dev device.Device, cfg config.Config) string {
-	hostForURL := dev.Host
-	if hostForURL == "" {
-		hostForURL = dev.Name.String()
+// scrapeHost returns the host used for client-metrics requests. The FQDN from
+// dev.Name (MagicDNS) is preferred because tsnet's resolver has no search
+// domain — a short OS-reported dev.Host fails to resolve there and causes
+// scrape timeouts. dev.Host is only used as a last resort.
+func scrapeHost(dev device.Device) string {
+	if name := dev.Name.String(); name != "" {
+		return name
 	}
-	host := net.JoinHostPort(hostForURL, cfg.ClientMetricsPort)
+	return dev.Host
+}
+
+func buildMetricsURL(dev device.Device, cfg config.Config) string {
+	host := net.JoinHostPort(scrapeHost(dev), cfg.ClientMetricsPort)
 	u := url.URL{Scheme: "http", Host: host, Path: "/metrics"}
 	return u.String()
 }
 
 func fetchDeviceMetrics(dev device.Device, client *http.Client, cfg config.Config) (*http.Response, error) {
-	hostForURL := dev.Host
-	if hostForURL == "" {
-		hostForURL = dev.Name.String()
-	}
+	hostForURL := scrapeHost(dev)
 
 	if err := validateHostname(hostForURL); err != nil {
 		return nil, fmt.Errorf("invalid hostname %s: %w", hostForURL, err)


### PR DESCRIPTION
## Summary

- Scraper URL construction preferred `dev.Host` (OS-reported short hostname) over `dev.Name` (MagicDNS FQDN), with `dev.Name` only used as fallback.
- In tsnet mode the embedded resolver has no search domain, so short hostnames fail to resolve and scrapes time out with `context deadline exceeded`.
- Swapped the preference via a `scrapeHost` helper so FQDN resolution via MagicDNS is the default path; `dev.Host` now only serves as last-resort fallback.

## Test plan

- [x] `go vet ./internal/metrics/` clean
- [x] `go test ./internal/metrics/` passes
- [ ] Verify live against tsnet: `just dev` + observe `scraping completed … errors=0` across multiple cycles