### PR TITLE
refactor(metrics): propagate scrape context and harden device URLs

### DIFF
--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -153,7 +153,9 @@ func (c *Collector) FetchDevices() ([]device.Device, error) {
 }
 
 // UpdateMetrics updates all device metrics for the specified target.
-func (c *Collector) UpdateMetrics(target string) error {
+// The context is propagated to concurrent device scrapes so that a parent
+// cancellation (shutdown, per-cycle timeout) stops in-flight requests.
+func (c *Collector) UpdateMetrics(ctx context.Context, target string) error {
 	start := time.Now()
 	defer func() {
 		ScrapeDuration.WithLabelValues(target).Observe(time.Since(start).Seconds())
@@ -349,7 +351,7 @@ func (c *Collector) UpdateMetrics(target string) error {
 
 	OnlineDevicesCount.Set(float64(onlineCount))
 
-	if err := ScrapeClientMetrics(devices, c.cfg); err != nil {
+	if err := ScrapeClientMetrics(ctx, devices, c.cfg); err != nil {
 		if errCount := CountTsnetStartupErrors(err); errCount > 0 {
 			slog.Debug("device scraping pending tsnet startup", "tsnet_startup_errors", errCount, "details", err)
 		} else {

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -197,7 +198,7 @@ func TestScrapeClient(t *testing.T) {
 
 	// Test with unreachable host
 	client := &http.Client{Timeout: 100 * time.Millisecond}
-	err := scrapeClient(device, client, cfg)
+	err := scrapeClient(context.Background(), device, client, cfg)
 
 	if err == nil {
 		t.Error("Expected error when connecting to unreachable host")

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -212,18 +212,20 @@ func fetchDeviceMetrics(ctx context.Context, dev device.Device, client *http.Cli
 
 	urlStr := buildMetricsURL(dev, cfg)
 
-	// SSRF-Härtung: Scraper darf nie Loopback, Link-Local oder Current-Network
-	// ansprechen — auch wenn die Tailscale-API einen manipulierten Hostnamen/IP-Literal
-	// liefert. RFC1918 und 100.64.0.0/10 (Tailscale CGNAT) sind bewusst erlaubt,
-	// da dort die zu scrapenden Geräte leben.
+	// SSRF hardening: the scraper must never reach loopback, link-local, or
+	// current-network addresses — even if the Tailscale API returns a
+	// manipulated hostname or IP literal. RFC1918 and 100.64.0.0/10 (Tailscale
+	// CGNAT) are intentionally allowed since that is where scraped devices
+	// live in the homelab/tailnet.
 	if err := validateDeviceMetricsURL(urlStr); err != nil {
 		return nil, fmt.Errorf("invalid device metrics URL %s: %w", urlStr, err)
 	}
 
-	// http.Client.Timeout deckt Connect + Headers + Body-Read ab, deshalb KEIN
-	// context.WithTimeout hier: das defer cancel() würde feuern, sobald diese
-	// Funktion zurückkehrt — und danach liest der Caller den Body noch. Ein
-	// früh abgebrochener reqCtx brach den Body-Read als "context canceled" ab.
+	// http.Client.Timeout covers connect + headers + body read, so we do NOT
+	// wrap with context.WithTimeout here: the deferred cancel() would fire as
+	// soon as this function returns — while the caller is still reading the
+	// response body. A prematurely cancelled reqCtx broke body reads as
+	// "context canceled".
 	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if reqErr != nil {
 		return nil, fmt.Errorf("failed to create request for %s: %w", urlStr, reqErr)
@@ -421,7 +423,10 @@ func init() {
 		"169.254.0.0/16", // IPv4 link-local (AWS/GCP/Azure instance metadata)
 		"fe80::/10",      // IPv6 link-local
 	} {
-		_, network, _ := net.ParseCIDR(cidr)
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("scraperBlockedIPNets: invalid CIDR %q: %v", cidr, err))
+		}
 		scraperBlockedIPNets = append(scraperBlockedIPNets, network)
 	}
 }

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -68,7 +68,9 @@ func SetHTTPClientProvider(provider HTTPClientProvider) {
 }
 
 // ScrapeClientMetrics scrapes metrics from the provided devices using the given configuration.
-func ScrapeClientMetrics(devices []device.Device, cfg config.Config) error {
+// The provided context is propagated to each per-device HTTP request so that a
+// parent shutdown cancels in-flight scrapes promptly.
+func ScrapeClientMetrics(ctx context.Context, devices []device.Device, cfg config.Config) error {
 	if cfg.TsnetScrapeTag != "" {
 		slog.Info("scraping devices with tag filter", "requiredTag", cfg.TsnetScrapeTag)
 	} else {
@@ -113,7 +115,7 @@ func ScrapeClientMetrics(devices []device.Device, cfg config.Config) error {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			if err := scrapeClient(dev, client, cfg); err != nil {
+			if err := scrapeClient(ctx, dev, client, cfg); err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Errorf("device %s: %w", dev.Name.String(), err))
 				mu.Unlock()
@@ -170,8 +172,8 @@ func isTsnetStartupError(err error) bool {
 		strings.Contains(errStr, "no such host")
 }
 
-func scrapeClient(dev device.Device, client *http.Client, cfg config.Config) error {
-	resp, err := fetchDeviceMetrics(dev, client, cfg)
+func scrapeClient(ctx context.Context, dev device.Device, client *http.Client, cfg config.Config) error {
+	resp, err := fetchDeviceMetrics(ctx, dev, client, cfg)
 	if err != nil {
 		return err
 	}
@@ -201,7 +203,7 @@ func buildMetricsURL(dev device.Device, cfg config.Config) string {
 	return u.String()
 }
 
-func fetchDeviceMetrics(dev device.Device, client *http.Client, cfg config.Config) (*http.Response, error) {
+func fetchDeviceMetrics(ctx context.Context, dev device.Device, client *http.Client, cfg config.Config) (*http.Response, error) {
 	hostForURL := scrapeHost(dev)
 
 	if err := validateHostname(hostForURL); err != nil {
@@ -209,7 +211,20 @@ func fetchDeviceMetrics(dev device.Device, client *http.Client, cfg config.Confi
 	}
 
 	urlStr := buildMetricsURL(dev, cfg)
-	req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, urlStr, nil)
+
+	// SSRF-Härtung: Scraper darf nie Loopback, Link-Local oder Current-Network
+	// ansprechen — auch wenn die Tailscale-API einen manipulierten Hostnamen/IP-Literal
+	// liefert. RFC1918 und 100.64.0.0/10 (Tailscale CGNAT) sind bewusst erlaubt,
+	// da dort die zu scrapenden Geräte leben.
+	if err := validateDeviceMetricsURL(urlStr); err != nil {
+		return nil, fmt.Errorf("invalid device metrics URL %s: %w", urlStr, err)
+	}
+
+	// http.Client.Timeout deckt Connect + Headers + Body-Read ab, deshalb KEIN
+	// context.WithTimeout hier: das defer cancel() würde feuern, sobald diese
+	// Funktion zurückkehrt — und danach liest der Caller den Body noch. Ein
+	// früh abgebrochener reqCtx brach den Body-Read als "context canceled" ab.
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if reqErr != nil {
 		return nil, fmt.Errorf("failed to create request for %s: %w", urlStr, reqErr)
 	}
@@ -388,6 +403,60 @@ func validateHostname(hostname string) error {
 	}
 	if !validHostnameRe.MatchString(hostname) {
 		return fmt.Errorf("hostname contains invalid characters (only letters, digits, dot, hyphen, and brackets allowed)")
+	}
+	return nil
+}
+
+// scraperBlockedIPNets contains IP ranges the scraper must never contact, even
+// if a compromised Tailscale API response injects such a literal host.
+// Notably RFC1918 and 100.64.0.0/10 (Tailscale CGNAT) are NOT blocked: those
+// are the exact ranges where legitimate devices live in a homelab/tailnet.
+var scraperBlockedIPNets []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"0.0.0.0/8",      // current network (RFC 1122) — never a valid destination
+		"127.0.0.0/8",    // IPv4 loopback — prevents hitting the exporter itself
+		"::1/128",        // IPv6 loopback
+		"169.254.0.0/16", // IPv4 link-local (AWS/GCP/Azure instance metadata)
+		"fe80::/10",      // IPv6 link-local
+	} {
+		_, network, _ := net.ParseCIDR(cidr)
+		scraperBlockedIPNets = append(scraperBlockedIPNets, network)
+	}
+}
+
+// validateDeviceMetricsURL parses a device metrics URL and rejects it if the
+// host resolves to a forbidden literal IP (loopback, link-local, current-net).
+// DNS names are accepted; DNS rebinding is out of scope because device hostnames
+// originate from the authenticated Tailscale API.
+func validateDeviceMetricsURL(urlStr string) error {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return fmt.Errorf("malformed URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme %q not allowed (only http/https)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	if strings.EqualFold(host, "localhost") {
+		return fmt.Errorf("host %q is not a permitted scrape target", host)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// DNS name — trust the Tailscale API as the source of truth.
+		return nil
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	for _, network := range scraperBlockedIPNets { // DevSkim: ignore DS162092 - intentionally enumerates loopback/link-local for SSRF validation
+		if network.Contains(ip) {
+			return fmt.Errorf("host %q is in a forbidden range %s", host, network.String())
+		}
 	}
 	return nil
 }

--- a/internal/metrics/scraper_test.go
+++ b/internal/metrics/scraper_test.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateDeviceMetricsURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string // substring; "" means no error
+	}{
+		// --- blocked literals ---
+		{"reject IPv4 loopback", "http://127.0.0.1:5252/metrics", "forbidden range"},
+		{"reject current-network zero", "http://0.0.0.0:5252/metrics", "forbidden range"},
+		{"reject IPv4 link-local (cloud metadata)", "http://169.254.169.254:5252/metrics", "forbidden range"},
+		{"reject IPv6 loopback", "http://[::1]:5252/metrics", "forbidden range"},
+		{"reject IPv6 link-local", "http://[fe80::1]:5252/metrics", "forbidden range"},
+		{"reject localhost string", "http://localhost:5252/metrics", "not a permitted scrape target"},
+		{"reject localhost string case-insensitive", "http://LocalHost:5252/metrics", "not a permitted scrape target"},
+
+		// --- allowed literals (tailnet / homelab ranges) ---
+		{"allow RFC1918 10/8", "http://10.0.0.1:5252/metrics", ""},
+		{"allow RFC1918 192.168/16", "http://192.168.1.1:5252/metrics", ""},
+		{"allow Tailscale CGNAT 100.64/10", "http://100.64.0.1:5252/metrics", ""},
+
+		// --- DNS names ---
+		{"allow MagicDNS FQDN", "http://device.tail1234.ts.net:5252/metrics", ""},
+		{"allow short hostname", "http://device:5252/metrics", ""},
+
+		// --- scheme enforcement ---
+		{"reject ftp scheme", "ftp://device.tail1234.ts.net/metrics", "scheme"},
+		{"reject file scheme", "file:///etc/passwd", "scheme"},
+
+		// --- malformed / edge cases ---
+		{"reject URL with no host", "http:///metrics", "no host"},
+		{"reject malformed URL", "http://%zz/metrics", "malformed URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDeviceMetricsURL(tt.url)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("validateDeviceMetricsURL(%q) unexpected error: %v", tt.url, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateDeviceMetricsURL(%q) expected error containing %q, got nil", tt.url, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("validateDeviceMetricsURL(%q) error = %v; want substring %q", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,6 +160,10 @@ func RunStandalone(cfg config.Config, ctx context.Context, collector *metrics.Co
 	return srv.Shutdown(shutdownCtx)
 }
 
+// scrapeCycleTimeout caps a single UpdateMetrics run so a hanging device cannot
+// block the next tick or delay shutdown beyond this budget.
+const scrapeCycleTimeout = 60 * time.Second
+
 func StartBackgroundScraper(cfg config.Config, ctx context.Context, collector *metrics.Collector) {
 	go func() {
 		if cfg.UseTsnet {
@@ -174,26 +178,26 @@ func StartBackgroundScraper(cfg config.Config, ctx context.Context, collector *m
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
-		if err := collector.UpdateMetrics("tailscale"); err != nil {
-			if cfg.UseTsnet && metrics.CountTsnetStartupErrors(err) > 0 {
-				slog.Info("Initial scrape waiting for connectivity")
-			} else {
-				slog.Error("initial update failed", "error", err)
+		runCycle := func(label string) {
+			cycleCtx, cancel := context.WithTimeout(ctx, scrapeCycleTimeout)
+			defer cancel()
+			if err := collector.UpdateMetrics(cycleCtx, "tailscale"); err != nil {
+				if cfg.UseTsnet && metrics.CountTsnetStartupErrors(err) > 0 {
+					slog.Debug(label+" waiting for connectivity", "tsnet_startup_errors", metrics.CountTsnetStartupErrors(err))
+				} else {
+					slog.Error(label+" failed", "error", err)
+				}
 			}
 		}
+
+		runCycle("initial update")
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := collector.UpdateMetrics("tailscale"); err != nil {
-					if cfg.UseTsnet && metrics.CountTsnetStartupErrors(err) > 0 {
-						slog.Debug("Scrape waiting for connectivity")
-					} else {
-						slog.Error("updateMetrics error", "error", err)
-					}
-				}
+				runCycle("updateMetrics")
 			}
 		}
 	}()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,9 +160,15 @@ func RunStandalone(cfg config.Config, ctx context.Context, collector *metrics.Co
 	return srv.Shutdown(shutdownCtx)
 }
 
-// scrapeCycleTimeout caps a single UpdateMetrics run so a hanging device cannot
-// block the next tick or delay shutdown beyond this budget.
-const scrapeCycleTimeout = 60 * time.Second
+// scrapeInterval and scrapeCycleTimeout bound the background scrape loop.
+// scrapeCycleTimeout must stay >= scrapeInterval: the ticker fires every
+// scrapeInterval, but time.Ticker silently drops ticks while runCycle is
+// still executing, so a slow cycle turns into backpressure rather than
+// overlapping runs.
+const (
+	scrapeInterval     = 30 * time.Second
+	scrapeCycleTimeout = 60 * time.Second
+)
 
 func StartBackgroundScraper(cfg config.Config, ctx context.Context, collector *metrics.Collector) {
 	go func() {
@@ -175,7 +181,7 @@ func StartBackgroundScraper(cfg config.Config, ctx context.Context, collector *m
 			}
 		}
 
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(scrapeInterval)
 		defer ticker.Stop()
 
 		runCycle := func(label string) {


### PR DESCRIPTION
Stacked on #72.

## Summary

- Thread `ctx` through `ScrapeClientMetrics` → `scrapeClient` → `fetchDeviceMetrics` so shutdown or per-cycle cancellation stops in-flight scrapes.
- Wrap each `UpdateMetrics` run in a 60s `context.WithTimeout` budget (`scrapeCycleTimeout`) in the background scraper, extracted into a `runCycle` helper.
- Add SSRF block list: reject device-metrics URLs whose host is a literal loopback, link-local, or current-network IP. RFC1918 and 100.64.0.0/10 (Tailscale CGNAT) stay allowed since legitimate tailnet devices live there.
- Pass `ctx` directly to `http.NewRequestWithContext` — `http.Client.Timeout` already bounds the full request (connect + headers + body read); an extra `context.WithTimeout` with `defer cancel()` would cancel the body read after the caller already started consuming the response.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/metrics/ ./internal/server/` passes
- [ ] Live check: `just dev` + observe `scraping completed ... errors=0` across multiple cycles with shutdown cancelling in-flight scrapes.