### PR TITLE
refactor(api): retry transient Tailscale API failures with backoff

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,11 +20,18 @@ import (
 	"github.com/sbaerlocher/tsmetrics/pkg/device"
 )
 
+const defaultAPIBase = "https://api.tailscale.com/api/v2"
+
 // Client provides HTTP client functionality for the Tailscale API.
 type Client struct {
 	httpClient  *http.Client
 	oauthConfig *clientcredentials.Config
-	baseURL     string
+	// baseURL is the tailnet-scoped root, e.g. "{apiBase}/tailnet/{tailnet}".
+	baseURL string
+	// apiBase is the unscoped API root, e.g. "https://api.tailscale.com/api/v2".
+	// Device-scoped calls (e.g. /device/{id}/routes) need this since the
+	// tailnet segment is not part of their path.
+	apiBase string
 }
 
 // NewClient creates a new Tailscale API client using OAuth credentials.
@@ -51,12 +60,15 @@ func NewClient(clientID, clientSecret, tailnet string) *Client {
 	return &Client{
 		httpClient:  httpClient,
 		oauthConfig: nil,
-		baseURL:     fmt.Sprintf("https://api.tailscale.com/api/v2/tailnet/%s", tailnet),
+		baseURL:     fmt.Sprintf("%s/tailnet/%s", defaultAPIBase, tailnet),
+		apiBase:     defaultAPIBase,
 	}
 }
 
 // NewClientWithBaseURL creates a client with a fully custom base URL.
 // Intended for use in tests where requests must be directed to an httptest.Server.
+// baseURL is expected to be the tailnet-scoped URL ({root}/tailnet/{tailnet});
+// the API base is derived from it so device-scoped calls hit the same server.
 func NewClientWithBaseURL(token, baseURL string) *Client {
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	httpClient.Transport = &tokenTransport{
@@ -66,7 +78,19 @@ func NewClientWithBaseURL(token, baseURL string) *Client {
 	return &Client{
 		httpClient: httpClient,
 		baseURL:    baseURL,
+		apiBase:    deriveAPIBase(baseURL),
 	}
+}
+
+// deriveAPIBase strips the trailing "/tailnet/{tailnet}" segment from a
+// tailnet-scoped URL so that device-scoped calls can be constructed against
+// the same server. If the expected segment is not present, the input is
+// returned unchanged — the caller will surface the resulting request URL.
+func deriveAPIBase(tailnetURL string) string {
+	if idx := strings.LastIndex(tailnetURL, "/tailnet/"); idx >= 0 {
+		return tailnetURL[:idx]
+	}
+	return tailnetURL
 }
 
 // NewClientWithToken creates a new Tailscale API client using a direct OAuth token.
@@ -90,7 +114,8 @@ func NewClientWithToken(token, tailnet string) *Client {
 	return &Client{
 		httpClient:  httpClient,
 		oauthConfig: nil,
-		baseURL:     fmt.Sprintf("https://api.tailscale.com/api/v2/tailnet/%s", tailnet),
+		baseURL:     fmt.Sprintf("%s/tailnet/%s", defaultAPIBase, tailnet),
+		apiBase:     defaultAPIBase,
 	}
 }
 
@@ -150,18 +175,25 @@ func (c *Client) makeDevicesRequest() (*http.Response, error) {
 // doWithRetry performs an HTTP request with exponential backoff for transient
 // failures (network errors, 429, 5xx). The response body of failed attempts
 // is always drained and closed before the next retry so that connections
-// can be reused from the pool.
+// can be reused from the pool. Jitter (±25%) is added to the base backoff to
+// avoid multiple instances synchronising on a recovering upstream, and the
+// server's Retry-After header is honoured when present on 429 responses.
 func (c *Client) doWithRetry(ctx context.Context, method, url, endpoint string) (*http.Response, error) {
 	retryCfg := tserrors.DefaultRetryConfig()
 
 	var lastErr error
 	var lastStatus int
+	var retryAfter time.Duration
 	for attempt := 0; attempt < retryCfg.MaxAttempts; attempt++ {
 		if attempt > 0 {
+			delay := withJitter(retryCfg.CalculateDelay(attempt - 1))
+			if retryAfter > delay {
+				delay = retryAfter
+			}
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(retryCfg.CalculateDelay(attempt - 1)):
+			case <-time.After(delay):
 			}
 		}
 
@@ -171,19 +203,25 @@ func (c *Client) doWithRetry(ctx context.Context, method, url, endpoint string) 
 		}
 
 		resp, err := c.httpClient.Do(req) //nolint:gosec // URL is constructed from configured baseURL, not user input
+		lastAttempt := attempt == retryCfg.MaxAttempts-1
 		if err != nil {
 			lastErr = err
-			slog.Warn("Tailscale API request failed, will retry",
-				"endpoint", endpoint, "attempt", attempt+1, "error", err)
+			slog.Warn("Tailscale API request failed",
+				"endpoint", endpoint, "attempt", attempt+1, "max_attempts", retryCfg.MaxAttempts, "error", err, "will_retry", !lastAttempt)
 			continue
 		}
 
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
 			lastStatus = resp.StatusCode
+			if resp.StatusCode == http.StatusTooManyRequests {
+				retryAfter = parseRetryAfter(resp.Header.Get("Retry-After"))
+			} else {
+				retryAfter = 0
+			}
 			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
 			_ = resp.Body.Close()
 			slog.Warn("Tailscale API returned retryable status",
-				"endpoint", endpoint, "status", resp.StatusCode, "attempt", attempt+1)
+				"endpoint", endpoint, "status", resp.StatusCode, "attempt", attempt+1, "max_attempts", retryCfg.MaxAttempts, "will_retry", !lastAttempt)
 			continue
 		}
 
@@ -194,6 +232,46 @@ func (c *Client) doWithRetry(ctx context.Context, method, url, endpoint string) 
 		return nil, fmt.Errorf("request failed after %d attempts: %w", retryCfg.MaxAttempts, lastErr)
 	}
 	return nil, fmt.Errorf("request failed after %d attempts: last status %d", retryCfg.MaxAttempts, lastStatus)
+}
+
+// withJitter adds a random ±25% jitter to d so concurrent clients stop
+// synchronising on a recovering upstream. Negative jitter is clamped to zero.
+func withJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	// Half-range: each side of the interval is 25% of d.
+	halfRange := int64(d) / 4
+	if halfRange == 0 {
+		return d
+	}
+	// rand.Int64N is safe for concurrent use (Go 1.22+) and suitable here —
+	// we do not need crypto-grade randomness for retry pacing.
+	offset := rand.Int64N(2*halfRange+1) - halfRange
+	jittered := int64(d) + offset
+	if jittered < 0 {
+		return 0
+	}
+	return time.Duration(jittered)
+}
+
+// parseRetryAfter parses the Retry-After header value. The header may be a
+// number of seconds (RFC 9110 §10.2.3) or an HTTP-date. Unparseable or
+// past-dated values yield a zero duration so the caller falls back to the
+// computed backoff.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 func (c *Client) handleAPIError(resp *http.Response) error {
@@ -473,7 +551,11 @@ type deviceRoutes struct {
 }
 
 func (c *Client) fetchDeviceRoutes(deviceID string) (*deviceRoutes, error) {
-	apiURL := fmt.Sprintf("https://api.tailscale.com/api/v2/device/%s/routes?fields=all", deviceID)
+	apiBase := c.apiBase
+	if apiBase == "" {
+		apiBase = deriveAPIBase(c.baseURL)
+	}
+	apiURL := fmt.Sprintf("%s/device/%s/routes?fields=all", apiBase, deviceID)
 	resp, err := c.doWithRetry(context.Background(), http.MethodGet, apiURL, "device_routes")
 	if err != nil {
 		return nil, fmt.Errorf("routes request failed: %w", err)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -130,12 +130,15 @@ func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.transport.RoundTrip(req)
 }
 
-func (c *Client) FetchDevices() ([]device.Device, error) {
+// FetchDevices lists tailnet devices. The context is propagated to each HTTP
+// call (devices listing + per-device routes) so a shutdown or per-cycle
+// timeout aborts in-flight retries rather than waiting for exhaustion.
+func (c *Client) FetchDevices(ctx context.Context) ([]device.Device, error) {
 	if c.baseURL == "" {
 		return nil, fmt.Errorf("no tailnet configured")
 	}
 
-	resp, err := c.makeDevicesRequest()
+	resp, err := c.makeDevicesRequest(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +153,15 @@ func (c *Client) FetchDevices() ([]device.Device, error) {
 		return nil, err
 	}
 
-	// Fetch routes for each device to determine exit node status
+	// Fetch routes for each device to determine exit node status. Abort the
+	// per-device loop early if ctx is cancelled so a shutdown does not wait
+	// for every remaining device's retry budget to drain.
 	devices := c.convertAPIDevices(result.Devices)
 	for i := range devices {
-		routes, err := c.fetchDeviceRoutes(devices[i].ID.String())
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		routes, err := c.fetchDeviceRoutes(ctx, devices[i].ID.String())
 		if err != nil {
 			slog.Warn("failed to fetch routes for device", "device", devices[i].Name, "error", err)
 			continue
@@ -167,9 +175,9 @@ func (c *Client) FetchDevices() ([]device.Device, error) {
 	return devices, nil
 }
 
-func (c *Client) makeDevicesRequest() (*http.Response, error) {
+func (c *Client) makeDevicesRequest(ctx context.Context) (*http.Response, error) {
 	apiURL := fmt.Sprintf("%s/devices?fields=all", c.baseURL)
-	return c.doWithRetry(context.Background(), http.MethodGet, apiURL, "devices")
+	return c.doWithRetry(ctx, http.MethodGet, apiURL, "devices")
 }
 
 // doWithRetry performs an HTTP request with exponential backoff for transient
@@ -553,13 +561,13 @@ type deviceRoutes struct {
 	EnabledRoutes    []string `json:"enabledRoutes"`
 }
 
-func (c *Client) fetchDeviceRoutes(deviceID string) (*deviceRoutes, error) {
+func (c *Client) fetchDeviceRoutes(ctx context.Context, deviceID string) (*deviceRoutes, error) {
 	apiBase := c.apiBase
 	if apiBase == "" {
 		apiBase = deriveAPIBase(c.baseURL)
 	}
 	apiURL := fmt.Sprintf("%s/device/%s/routes?fields=all", apiBase, deviceID)
-	resp, err := c.doWithRetry(context.Background(), http.MethodGet, apiURL, "device_routes")
+	resp, err := c.doWithRetry(ctx, http.MethodGet, apiURL, "device_routes")
 	if err != nil {
 		return nil, fmt.Errorf("routes request failed: %w", err)
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/oauth2/clientcredentials"
 
+	tserrors "github.com/sbaerlocher/tsmetrics/internal/errors"
 	"github.com/sbaerlocher/tsmetrics/internal/types"
 	"github.com/sbaerlocher/tsmetrics/pkg/device"
 )
@@ -143,16 +144,56 @@ func (c *Client) FetchDevices() ([]device.Device, error) {
 
 func (c *Client) makeDevicesRequest() (*http.Response, error) {
 	apiURL := fmt.Sprintf("%s/devices?fields=all", c.baseURL)
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	return c.doWithRetry(context.Background(), http.MethodGet, apiURL, "devices")
+}
+
+// doWithRetry performs an HTTP request with exponential backoff for transient
+// failures (network errors, 429, 5xx). The response body of failed attempts
+// is always drained and closed before the next retry so that connections
+// can be reused from the pool.
+func (c *Client) doWithRetry(ctx context.Context, method, url, endpoint string) (*http.Response, error) {
+	retryCfg := tserrors.DefaultRetryConfig()
+
+	var lastErr error
+	var lastStatus int
+	for attempt := 0; attempt < retryCfg.MaxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryCfg.CalculateDelay(attempt - 1)):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req) //nolint:gosec // URL is constructed from configured baseURL, not user input
+		if err != nil {
+			lastErr = err
+			slog.Warn("Tailscale API request failed, will retry",
+				"endpoint", endpoint, "attempt", attempt+1, "error", err)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastStatus = resp.StatusCode
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+			_ = resp.Body.Close()
+			slog.Warn("Tailscale API returned retryable status",
+				"endpoint", endpoint, "status", resp.StatusCode, "attempt", attempt+1)
+			continue
+		}
+
+		return resp, nil
 	}
 
-	resp, err := c.httpClient.Do(req) //nolint:gosec // URL is constructed from configured baseURL, not user input
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+	if lastErr != nil {
+		return nil, fmt.Errorf("request failed after %d attempts: %w", retryCfg.MaxAttempts, lastErr)
 	}
-	return resp, nil
+	return nil, fmt.Errorf("request failed after %d attempts: last status %d", retryCfg.MaxAttempts, lastStatus)
 }
 
 func (c *Client) handleAPIError(resp *http.Response) error {
@@ -433,12 +474,7 @@ type deviceRoutes struct {
 
 func (c *Client) fetchDeviceRoutes(deviceID string) (*deviceRoutes, error) {
 	apiURL := fmt.Sprintf("https://api.tailscale.com/api/v2/device/%s/routes?fields=all", deviceID)
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create routes request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req) //nolint:gosec // URL is constructed from known API base + validated device ID
+	resp, err := c.doWithRetry(context.Background(), http.MethodGet, apiURL, "device_routes")
 	if err != nil {
 		return nil, fmt.Errorf("routes request failed: %w", err)
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -246,8 +246,11 @@ func withJitter(d time.Duration) time.Duration {
 		return d
 	}
 	// rand.Int64N is safe for concurrent use (Go 1.22+) and suitable here —
-	// we do not need crypto-grade randomness for retry pacing.
-	offset := rand.Int64N(2*halfRange+1) - halfRange
+	// retry pacing does not need crypto-grade randomness and the jittered
+	// delay is not security-sensitive.
+	//
+	// #nosec G404 -- non-crypto RNG is appropriate for retry backoff jitter
+	offset := rand.Int64N(2*halfRange+1) - halfRange //nolint:gosec // G404: see comment above
 	jittered := int64(d) + offset
 	if jittered < 0 {
 		return 0

--- a/internal/api/client_retry_test.go
+++ b/internal/api/client_retry_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// retryTestClient builds a Client pointed at srv with the retry helper
+// reachable directly. It uses the real DefaultRetryConfig (100ms base), so
+// each failing attempt adds a small delay — tests assert behaviour, not exact
+// timing, except where explicitly annotated.
+func retryTestClient(srv *httptest.Server) *Client {
+	return &Client{
+		httpClient: srv.Client(),
+		baseURL:    srv.URL,
+		apiBase:    srv.URL,
+	}
+}
+
+// statusSequenceHandler returns each status in sequence; extra requests
+// after the sequence ends reuse the last entry so callers cannot index OOB.
+func statusSequenceHandler(statuses []int, headers ...http.Header) (http.HandlerFunc, *int) {
+	var calls int
+	return func(w http.ResponseWriter, _ *http.Request) {
+		i := calls
+		calls++
+		if i >= len(statuses) {
+			i = len(statuses) - 1
+		}
+		if i < len(headers) {
+			for k, v := range headers[i] {
+				for _, vv := range v {
+					w.Header().Add(k, vv)
+				}
+			}
+		}
+		w.WriteHeader(statuses[i])
+		_, _ = fmt.Fprintf(w, "attempt %d\n", calls)
+	}, &calls
+}
+
+func TestDoWithRetry_Retries5xxThenSucceeds(t *testing.T) {
+	handler, calls := statusSequenceHandler([]int{500, 500, 200})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := retryTestClient(srv)
+	resp, err := c.doWithRetry(context.Background(), http.MethodGet, srv.URL+"/x", "test")
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if *calls != 3 {
+		t.Errorf("calls = %d, want 3 (two failures + one success)", *calls)
+	}
+}
+
+func TestDoWithRetry_Retries429ThenSucceeds(t *testing.T) {
+	handler, calls := statusSequenceHandler([]int{429, 200})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := retryTestClient(srv)
+	resp, err := c.doWithRetry(context.Background(), http.MethodGet, srv.URL+"/x", "test")
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if *calls != 2 {
+		t.Errorf("calls = %d, want 2", *calls)
+	}
+}
+
+func TestDoWithRetry_ExhaustedReturnsError(t *testing.T) {
+	handler, calls := statusSequenceHandler([]int{500, 500, 500, 500})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := retryTestClient(srv)
+	resp, err := c.doWithRetry(context.Background(), http.MethodGet, srv.URL+"/x", "test")
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected error after exhausting attempts, got nil")
+	}
+	if !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Errorf("error = %v, want reference to attempt count", err)
+	}
+	if *calls != 3 {
+		t.Errorf("calls = %d, want 3 (MaxAttempts from DefaultRetryConfig)", *calls)
+	}
+}
+
+func TestDoWithRetry_RespectsRetryAfterHeader(t *testing.T) {
+	// The server asks for a 250ms wait on the first 429, then returns 200.
+	// DefaultRetryConfig's base delay is 100ms — without Retry-After we'd
+	// wait ~100ms. With Retry-After honoured we expect to wait ≥250ms.
+	// Retry-After is in whole seconds per RFC 9110, so 1s is the smallest
+	// value that exercises the path.
+	handler, _ := statusSequenceHandler(
+		[]int{429, 200},
+		http.Header{"Retry-After": []string{"1"}},
+		http.Header{},
+	)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := retryTestClient(srv)
+	start := time.Now()
+	resp, err := c.doWithRetry(context.Background(), http.MethodGet, srv.URL+"/x", "test")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("elapsed = %v, expected retry to wait ~1s for Retry-After", elapsed)
+	}
+}
+
+func TestDoWithRetry_ContextCancellationInterrupts(t *testing.T) {
+	// Server always returns 500 so we stay in the retry loop.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	c := retryTestClient(srv)
+	start := time.Now()
+	_, err := c.doWithRetry(ctx, http.MethodGet, srv.URL+"/x", "test")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	// Should exit promptly once the context expires during backoff — well
+	// before 300ms (the total budget of 3 attempts with 100ms + 200ms waits).
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("elapsed = %v, expected prompt exit on ctx cancellation", elapsed)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"abc", 0},
+		{"0", 0},
+		{"-1", 0},
+		{"5", 5 * time.Second},
+		{" 10 ", 10 * time.Second},
+	}
+	for _, tt := range tests {
+		if got := parseRetryAfter(tt.in); got != tt.want {
+			t.Errorf("parseRetryAfter(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+
+	// HTTP-date in the past: 0; HTTP-date in the future: > 0.
+	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(future); got <= 0 || got > 30*time.Second {
+		t.Errorf("parseRetryAfter(future) = %v, want >0 and <=30s", got)
+	}
+	past := time.Now().Add(-30 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(past); got != 0 {
+		t.Errorf("parseRetryAfter(past) = %v, want 0", got)
+	}
+}
+
+func TestWithJitter_BoundsAndZero(t *testing.T) {
+	if got := withJitter(0); got != 0 {
+		t.Errorf("withJitter(0) = %v, want 0", got)
+	}
+	// Single-ns durations have a zero half-range and must round-trip.
+	if got := withJitter(time.Nanosecond); got != time.Nanosecond {
+		t.Errorf("withJitter(1ns) = %v, want 1ns", got)
+	}
+	// Bulk test: 1000 samples must all fall within ±25% of 400ms.
+	base := 400 * time.Millisecond
+	for range 1000 {
+		got := withJitter(base)
+		if got < 300*time.Millisecond || got > 500*time.Millisecond {
+			t.Fatalf("withJitter(%v) = %v out of ±25%% bounds", base, got)
+		}
+	}
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -127,7 +128,7 @@ func TestClientFetchDevices(t *testing.T) {
 		baseURL: "https://api.tailscale.com/api/v2/tailnet/test-tailnet",
 	}
 
-	devices, err := client.FetchDevices()
+	devices, err := client.FetchDevices(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -173,7 +174,7 @@ func TestClientFetchDevicesError(t *testing.T) {
 		baseURL: "https://api.tailscale.com/api/v2/tailnet/test-tailnet",
 	}
 
-	devices, err := client.FetchDevices()
+	devices, err := client.FetchDevices(context.Background())
 	if err == nil {
 		t.Fatal("Expected error for 500 status code")
 	}
@@ -208,7 +209,7 @@ func TestClientWithRealServer(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	devices, err := client.FetchDevices()
+	devices, err := client.FetchDevices(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -234,7 +235,7 @@ func TestClientTimeout(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	_, err := client.FetchDevices()
+	_, err := client.FetchDevices(context.Background())
 	if err == nil {
 		t.Fatal("Expected timeout error")
 	}
@@ -373,7 +374,7 @@ func TestClientExitNodeDetection(t *testing.T) {
 		baseURL: "https://api.tailscale.com/api/v2/tailnet/test-tailnet",
 	}
 
-	devicesResult, err := client.FetchDevices()
+	devicesResult, err := client.FetchDevices(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -69,8 +69,10 @@ func NewCollector(cfg config.Config) *Collector {
 	}
 }
 
-// FetchDevices retrieves the list of devices from the Tailscale API or returns test devices.
-func (c *Collector) FetchDevices() ([]device.Device, error) {
+// FetchDevices retrieves the list of devices from the Tailscale API or returns
+// test devices. The context is propagated to the API client so a shutdown or
+// per-cycle timeout can abort in-flight retries on the devices + routes calls.
+func (c *Collector) FetchDevices(ctx context.Context) ([]device.Device, error) {
 	targetDevices := []string{}
 	if v := os.Getenv("TARGET_DEVICES"); v != "" {
 		for _, part := range strings.Split(v, ",") {
@@ -101,7 +103,7 @@ func (c *Collector) FetchDevices() ([]device.Device, error) {
 
 	if c.apiClient != nil {
 		slog.Info("attempting Tailscale API discovery")
-		devices, err := c.apiClient.FetchDevices()
+		devices, err := c.apiClient.FetchDevices(ctx)
 		if err != nil {
 			slog.Error("Tailscale API failed", "error", err)
 		} else {
@@ -161,7 +163,7 @@ func (c *Collector) UpdateMetrics(ctx context.Context, target string) error {
 		ScrapeDuration.WithLabelValues(target).Observe(time.Since(start).Seconds())
 	}()
 
-	devices, err := c.FetchDevices()
+	devices, err := c.FetchDevices(ctx)
 	if err != nil {
 		ScrapeErrors.WithLabelValues(target, "fetch_failed").Inc()
 		return err

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -43,7 +43,7 @@ func TestFetchDevicesWithoutAPI(t *testing.T) {
 	}
 
 	collector := NewCollector(cfg)
-	devices, err := collector.FetchDevices()
+	devices, err := collector.FetchDevices(context.Background())
 
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)


### PR DESCRIPTION
## Summary

- Introduce a shared `doWithRetry` helper in the Tailscale API client using `tserrors.DefaultRetryConfig()` for exponential backoff.
- Retry on network errors, 429 rate limits, and 5xx server errors; drain + close failed response bodies so connections return to the pool.
- Wire the helper into `FetchDevices` and `fetchDeviceRoutes`, so a transient upstream hiccup no longer loses a full scrape cycle.

## Test plan

- [x] `go vet ./internal/api/` clean
- [x] `go test ./internal/api/` passes