### PR TITLE
refactor: harden bind-host detection, token auth, and handler reuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 
 # Server Configuration
 PORT=9100
+# BIND_HOST overrides the listen interface. Default: auto-detected —
+# 0.0.0.0 in containers (Docker/Kubernetes), 127.0.0.1 on a host.
+# Only set if auto-detection picks the wrong one for your runtime.
+# BIND_HOST=0.0.0.0
 
 # OAuth2 Configuration (Option 1 - OAuth Client Credentials Flow)
 OAUTH_CLIENT_ID=your_client_id_here
@@ -30,11 +34,8 @@ MAX_CONCURRENT_SCRAPES=10
 CLIENT_METRICS_PORT=5252
 
 # Device Configuration
-TARGET_DEVICES=gateway-140207,gateway-130104,router.local
+TARGET_DEVICES=device-1.example.ts.net,device-2.example.ts.net
 # TEST_DEVICES=device1,device2  # Deprecated: use TARGET_DEVICES instead
-
-# Environment
-ENV=development         # development, production
 
 # Build Information (auto-populated during build)
 # VERSION=v1.0.0

--- a/cmd/tsmetrics/main.go
+++ b/cmd/tsmetrics/main.go
@@ -155,6 +155,11 @@ func main() {
 
 	server.SetVersion(version, buildTime)
 
+	collector := metrics.NewCollector(cfg)
+	// Share the collector's Tailscale API client with the HTTP handlers so
+	// /health does not reconstruct an oauth2.Client on every probe.
+	server.SetAPIClient(collector.APIClient())
+
 	slog.Info("Starting tsmetrics",
 		"version", version,
 		"build_time", buildTime,
@@ -164,8 +169,6 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-
-	collector := metrics.NewCollector(cfg)
 
 	var err error
 	if cfg.UseTsnet {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	TsnetStateSecret     string
 	TsnetAuthKey         string
 	Port                 string
+	BindHost             string
 	OAuthClientID        string
 	OAuthSecret          string //nolint:gosec // G117: not a hardcoded credential, loaded from env
 	TailnetName          string
@@ -49,6 +50,8 @@ func (cfg *Config) loadNetworkSettings() {
 		cfg.Port = "9100"
 	}
 
+	cfg.BindHost = resolveBindHost()
+
 	cfg.ClientMetricsPort = "5252"
 	if v := os.Getenv("CLIENT_METRICS_PORT"); v != "" {
 		cfg.ClientMetricsPort = v
@@ -60,6 +63,39 @@ func (cfg *Config) loadNetworkSettings() {
 			cfg.MaxConcurrentScrapes = n
 		}
 	}
+}
+
+// resolveBindHost returns the listen address for the HTTP server.
+// BIND_HOST env wins; otherwise auto-detect: containers → 0.0.0.0, host → loopback.
+func resolveBindHost() string {
+	if v := strings.TrimSpace(os.Getenv("BIND_HOST")); v != "" {
+		return v
+	}
+	if detectContainer() {
+		slog.Debug("container runtime detected, binding on all interfaces")
+		return "0.0.0.0"
+	}
+	return "127.0.0.1" // DevSkim: ignore DS162092 - Host-native default avoids exposing metrics on a dev LAN
+}
+
+// detectContainer heuristically identifies whether the process runs inside
+// a containerized runtime (Docker, Kubernetes, containerd, etc.).
+func detectContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return true
+	}
+	if b, err := os.ReadFile("/proc/self/cgroup"); err == nil {
+		s := string(b)
+		for _, marker := range []string{"/docker/", "/kubepods/", "/containerd/", "/docker-", "/lxc/"} {
+			if strings.Contains(s, marker) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (cfg *Config) loadAuthSettings() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,9 @@ func resolveBindHost() string {
 }
 
 // detectContainer heuristically identifies whether the process runs inside
-// a containerized runtime (Docker, Kubernetes, containerd, etc.).
+// a containerized runtime (Docker, Kubernetes, containerd, etc.). When the
+// heuristic fails (e.g. a cgroups-v2 host with no container markers exposed
+// to the process), operators can force the result via BIND_HOST.
 func detectContainer() bool {
 	if _, err := os.Stat("/.dockerenv"); err == nil {
 		return true
@@ -87,9 +89,25 @@ func detectContainer() bool {
 	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
 		return true
 	}
+	// cgroups v1: the hierarchy paths in /proc/self/cgroup carry the runtime
+	// slice name ("/docker/<id>", "/kubepods/...", etc.). On cgroups v2 the
+	// file typically collapses to "0::/" and these markers disappear, so the
+	// v1 read is checked first and the v2 fallback below covers the rest.
 	if b, err := os.ReadFile("/proc/self/cgroup"); err == nil {
 		s := string(b)
 		for _, marker := range []string{"/docker/", "/kubepods/", "/containerd/", "/docker-", "/lxc/"} {
+			if strings.Contains(s, marker) {
+				return true
+			}
+		}
+	}
+	// cgroups v2 fallback: container mount namespaces surface their overlay
+	// root (and frequently the container id) in /proc/self/mountinfo even
+	// when /proc/self/cgroup is generic. Match on the overlay filesystem
+	// type plus the runtime-specific paths used by Docker/Podman/K8s.
+	if b, err := os.ReadFile("/proc/self/mountinfo"); err == nil {
+		s := string(b)
+		for _, marker := range []string{"/docker/containers/", "/containers/storage/overlay", "/kubelet/pods/"} {
 			if strings.Contains(s, marker) {
 				return true
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -234,3 +234,31 @@ func TestSetupTsnetStateDir(t *testing.T) {
 		t.Errorf("Expected directory %s to be created", customDir)
 	}
 }
+
+func TestResolveBindHost_EnvOverrideWins(t *testing.T) {
+	t.Setenv("BIND_HOST", "192.0.2.10")
+	if got := resolveBindHost(); got != "192.0.2.10" {
+		t.Errorf("resolveBindHost() with BIND_HOST set = %q, want %q", got, "192.0.2.10")
+	}
+}
+
+func TestResolveBindHost_EnvOverrideIsTrimmed(t *testing.T) {
+	t.Setenv("BIND_HOST", "   0.0.0.0   ")
+	if got := resolveBindHost(); got != "0.0.0.0" {
+		t.Errorf("resolveBindHost() with whitespaced BIND_HOST = %q, want %q", got, "0.0.0.0")
+	}
+}
+
+func TestResolveBindHost_HostFallback(t *testing.T) {
+	// Explicitly clear BIND_HOST so the auto-detection path runs. On a host
+	// (no /.dockerenv, no KUBERNETES_SERVICE_HOST, no container cgroup/mount
+	// markers) the fallback must be loopback — binding 0.0.0.0 on a dev
+	// workstation would expose metrics on the LAN.
+	t.Setenv("BIND_HOST", "")
+	if detectContainer() {
+		t.Skip("running inside a container-detected environment; host fallback path not exercised")
+	}
+	if got := resolveBindHost(); got != "127.0.0.1" {
+		t.Errorf("resolveBindHost() on non-container host = %q, want %q", got, "127.0.0.1")
+	}
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -46,6 +46,14 @@ type Collector struct {
 	tracker   *DeviceMetricsTracker
 }
 
+// APIClient returns the underlying Tailscale API client, or nil if the
+// collector was initialized without OAuth credentials. Callers (e.g. the
+// HTTP health handler) use this to avoid re-running the OAuth flow per
+// request.
+func (c *Collector) APIClient() *api.Client {
+	return c.apiClient
+}
+
 // NewCollector creates a new metrics collector with the given configuration.
 func NewCollector(cfg config.Config) *Collector {
 	var apiClient *api.Client

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -168,50 +168,93 @@ func (iv *InputValidator) ValidateDeviceID(id string) error {
 }
 
 // Rate Limiting
-// RateLimiter provides per-client rate limiting functionality.
-type RateLimiter struct {
-	limiters map[string]*rate.Limiter
-	mutex    sync.RWMutex
-	rate     rate.Limit
-	burst    int
+// limiterEntry bundles a rate.Limiter with the last time it was touched, so
+// the cleanup routine can evict entries that have been idle for a while.
+type limiterEntry struct {
+	limiter  *rate.Limiter
+	lastUsed time.Time
 }
+
+// RateLimiter provides per-client rate limiting functionality.
+// maxEntries caps the map size so that a burst of unique client IDs
+// (spoofed/rotating source IPs) cannot exhaust memory; idleTTL is the
+// minimum time an entry must be idle before Cleanup may evict it.
+type RateLimiter struct {
+	entries    map[string]*limiterEntry
+	mutex      sync.RWMutex
+	rate       rate.Limit
+	burst      int
+	maxEntries int
+	idleTTL    time.Duration
+	now        func() time.Time
+}
+
+const (
+	defaultMaxRateLimiterEntries = 10000
+	defaultRateLimiterIdleTTL    = 1 * time.Hour
+)
 
 // NewRateLimiter creates a new rate limiter with the specified requests per second and burst size.
 func NewRateLimiter(rps float64, burst int) *RateLimiter {
 	return &RateLimiter{
-		limiters: make(map[string]*rate.Limiter),
-		rate:     rate.Limit(rps),
-		burst:    burst,
+		entries:    make(map[string]*limiterEntry),
+		rate:       rate.Limit(rps),
+		burst:      burst,
+		maxEntries: defaultMaxRateLimiterEntries,
+		idleTTL:    defaultRateLimiterIdleTTL,
+		now:        time.Now,
 	}
 }
 
 func (rl *RateLimiter) Allow(clientID string) bool {
-	rl.mutex.RLock()
-	limiter, exists := rl.limiters[clientID]
-	rl.mutex.RUnlock()
-
+	rl.mutex.Lock()
+	entry, exists := rl.entries[clientID]
 	if !exists {
-		rl.mutex.Lock()
-		// Double-check pattern
-		if limiter, exists = rl.limiters[clientID]; !exists {
-			limiter = rate.NewLimiter(rl.rate, rl.burst)
-			rl.limiters[clientID] = limiter
+		// Evict the oldest entry first if we are at capacity. This keeps the
+		// map bounded under a sustained burst of unique client IDs.
+		if len(rl.entries) >= rl.maxEntries {
+			rl.evictOldestLocked()
 		}
-		rl.mutex.Unlock()
+		entry = &limiterEntry{
+			limiter: rate.NewLimiter(rl.rate, rl.burst),
+		}
+		rl.entries[clientID] = entry
 	}
+	entry.lastUsed = rl.now()
+	limiter := entry.limiter
+	rl.mutex.Unlock()
 
 	return limiter.Allow()
 }
 
+// evictOldestLocked removes the entry with the oldest lastUsed timestamp.
+// Caller must hold rl.mutex for writing.
+func (rl *RateLimiter) evictOldestLocked() {
+	var oldestKey string
+	var oldestTime time.Time
+	first := true
+	for k, e := range rl.entries {
+		if first || e.lastUsed.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = e.lastUsed
+			first = false
+		}
+	}
+	if !first {
+		delete(rl.entries, oldestKey)
+	}
+}
+
+// Cleanup removes entries that have been idle for longer than idleTTL.
+// Intended to be invoked periodically by a background goroutine.
 func (rl *RateLimiter) Cleanup() {
-	// Periodically clean up unused limiters
 	rl.mutex.Lock()
 	defer rl.mutex.Unlock()
 
-	for clientID, limiter := range rl.limiters {
-		// Remove limiters that haven't been used recently
-		if limiter.Tokens() >= float64(rl.burst) {
-			delete(rl.limiters, clientID)
+	cutoff := rl.now().Add(-rl.idleTTL)
+	for clientID, entry := range rl.entries {
+		if entry.lastUsed.Before(cutoff) {
+			delete(rl.entries, clientID)
 		}
 	}
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -170,9 +171,11 @@ func (iv *InputValidator) ValidateDeviceID(id string) error {
 // Rate Limiting
 // limiterEntry bundles a rate.Limiter with the last time it was touched, so
 // the cleanup routine can evict entries that have been idle for a while.
+// lastUsed is an int64 UnixNano stored atomically so the hot Allow() path
+// can refresh it under the map's read lock without upgrading to a writer.
 type limiterEntry struct {
 	limiter  *rate.Limiter
-	lastUsed time.Time
+	lastUsed atomic.Int64
 }
 
 // RateLimiter provides per-client rate limiting functionality.
@@ -206,12 +209,34 @@ func NewRateLimiter(rps float64, burst int) *RateLimiter {
 	}
 }
 
+// Allow reports whether a request from clientID may proceed. The hot path —
+// an already-known client — completes under the reader lock and updates
+// lastUsed atomically, so concurrent requests from different IPs do not
+// serialise on a single writer. A new client (or an at-capacity eviction)
+// upgrades to a writer, with a double-check after acquiring the write lock
+// to handle races where another goroutine created the entry in between.
+//
+// At capacity the eviction is O(n) over the map since we pick the oldest
+// entry by scanning lastUsed. With the default cap of 10 000 entries and
+// eviction only happening on a new-client insert after the map is full,
+// this is acceptable; if the workload ever needs faster eviction a heap
+// keyed by lastUsed would give O(log n).
 func (rl *RateLimiter) Allow(clientID string) bool {
+	// Fast path under reader lock: already-known client.
+	rl.mutex.RLock()
+	if entry, ok := rl.entries[clientID]; ok {
+		entry.lastUsed.Store(rl.now().UnixNano())
+		limiter := entry.limiter
+		rl.mutex.RUnlock()
+		return limiter.Allow()
+	}
+	rl.mutex.RUnlock()
+
+	// Slow path: create the entry (or pick up one created by a racing
+	// goroutine) under the writer lock.
 	rl.mutex.Lock()
 	entry, exists := rl.entries[clientID]
 	if !exists {
-		// Evict the oldest entry first if we are at capacity. This keeps the
-		// map bounded under a sustained burst of unique client IDs.
 		if len(rl.entries) >= rl.maxEntries {
 			rl.evictOldestLocked()
 		}
@@ -220,7 +245,7 @@ func (rl *RateLimiter) Allow(clientID string) bool {
 		}
 		rl.entries[clientID] = entry
 	}
-	entry.lastUsed = rl.now()
+	entry.lastUsed.Store(rl.now().UnixNano())
 	limiter := entry.limiter
 	rl.mutex.Unlock()
 
@@ -231,12 +256,13 @@ func (rl *RateLimiter) Allow(clientID string) bool {
 // Caller must hold rl.mutex for writing.
 func (rl *RateLimiter) evictOldestLocked() {
 	var oldestKey string
-	var oldestTime time.Time
+	var oldestNanos int64
 	first := true
 	for k, e := range rl.entries {
-		if first || e.lastUsed.Before(oldestTime) {
+		used := e.lastUsed.Load()
+		if first || used < oldestNanos {
 			oldestKey = k
-			oldestTime = e.lastUsed
+			oldestNanos = used
 			first = false
 		}
 	}
@@ -251,9 +277,9 @@ func (rl *RateLimiter) Cleanup() {
 	rl.mutex.Lock()
 	defer rl.mutex.Unlock()
 
-	cutoff := rl.now().Add(-rl.idleTTL)
+	cutoffNanos := rl.now().Add(-rl.idleTTL).UnixNano()
 	for clientID, entry := range rl.entries {
-		if entry.lastUsed.Before(cutoff) {
+		if entry.lastUsed.Load() < cutoffNanos {
 			delete(rl.entries, clientID)
 		}
 	}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -516,31 +516,76 @@ func TestGenerateSecurityAuditReport(t *testing.T) {
 }
 
 func TestRateLimiterCleanup(t *testing.T) {
-	limiter := NewRateLimiter(10.0, 5) // High rate for testing
+	limiter := NewRateLimiter(10.0, 5)
 
-	// Create some limiters
+	// Freeze time so we can advance it deterministically.
+	base := time.Unix(1_700_000_000, 0)
+	current := base
+	limiter.now = func() time.Time { return current }
+	limiter.idleTTL = 30 * time.Second
+
 	limiter.Allow("client1")
 	limiter.Allow("client2")
 
-	// Check initial state
 	limiter.mutex.RLock()
-	initialCount := len(limiter.limiters)
+	initialCount := len(limiter.entries)
 	limiter.mutex.RUnlock()
-
 	if initialCount != 2 {
-		t.Errorf("Expected 2 limiters, got %d", initialCount)
+		t.Fatalf("expected 2 entries, got %d", initialCount)
 	}
 
-	// Wait for limiters to reset to full capacity, then cleanup
-	time.Sleep(100 * time.Millisecond)
+	// Still within the idle TTL — cleanup must not evict.
+	current = base.Add(10 * time.Second)
 	limiter.Cleanup()
+	limiter.mutex.RLock()
+	kept := len(limiter.entries)
+	limiter.mutex.RUnlock()
+	if kept != 2 {
+		t.Errorf("expected 2 entries after in-TTL cleanup, got %d", kept)
+	}
+
+	// Advance past idle TTL — both entries should be evicted.
+	current = base.Add(2 * time.Hour)
+	limiter.Cleanup()
+	limiter.mutex.RLock()
+	final := len(limiter.entries)
+	limiter.mutex.RUnlock()
+	if final != 0 {
+		t.Errorf("expected 0 entries after idle eviction, got %d", final)
+	}
+}
+
+func TestRateLimiterMaxEntries(t *testing.T) {
+	limiter := NewRateLimiter(10.0, 5)
+	limiter.maxEntries = 3
+
+	// Fill to capacity, advancing time so each entry has a distinct lastUsed.
+	base := time.Unix(1_700_000_000, 0)
+	current := base
+	limiter.now = func() time.Time { return current }
+
+	for i, id := range []string{"a", "b", "c"} {
+		current = base.Add(time.Duration(i) * time.Second)
+		limiter.Allow(id)
+	}
+
+	// Inserting a fourth entry must evict the oldest ("a") rather than grow the map.
+	current = base.Add(10 * time.Second)
+	limiter.Allow("d")
 
 	limiter.mutex.RLock()
-	finalCount := len(limiter.limiters)
+	size := len(limiter.entries)
+	_, hasA := limiter.entries["a"]
+	_, hasD := limiter.entries["d"]
 	limiter.mutex.RUnlock()
 
-	// Limiters at full capacity should be cleaned up
-	if finalCount >= initialCount {
-		t.Errorf("Cleanup should have removed some limiters, initial: %d, final: %d", initialCount, finalCount)
+	if size != 3 {
+		t.Errorf("expected map size 3 after LRU eviction, got %d", size)
+	}
+	if hasA {
+		t.Error("oldest entry 'a' should have been evicted")
+	}
+	if !hasD {
+		t.Error("newest entry 'd' should be present")
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -22,6 +22,12 @@ var (
 	// configured; reused across every /health request to avoid re-running the
 	// OAuth2 client-credentials flow and allocating a new http.Transport per
 	// probe (Prometheus/Kubernetes can hit /health every few seconds).
+	//
+	// Contract: SetAPIClient MUST be called from main() before the HTTP server
+	// starts serving traffic, and MUST NOT be called again afterwards. Handler
+	// goroutines read this pointer without synchronisation, so a post-startup
+	// rewrite would be a data race. Runtime credential rotation is out of
+	// scope today; if it is ever added, convert this to an atomic.Pointer.
 	apiClient *api.Client
 )
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/sbaerlocher/tsmetrics/internal/api"
@@ -19,6 +18,11 @@ var (
 	buildTime     = "unknown"
 	startTime     = time.Now()
 	healthChecker *health.HealthChecker
+	// apiClient is initialized once at startup when OAuth credentials are
+	// configured; reused across every /health request to avoid re-running the
+	// OAuth2 client-credentials flow and allocating a new http.Transport per
+	// probe (Prometheus/Kubernetes can hit /health every few seconds).
+	apiClient *api.Client
 )
 
 // SetVersion sets the global version and build time for handlers.
@@ -32,6 +36,13 @@ func SetHealthChecker(hc *health.HealthChecker) {
 	healthChecker = hc
 }
 
+// SetAPIClient stores the singleton API client used by health handlers.
+// Passing nil marks the API as not configured; subsequent health probes
+// will report "not_configured" instead of attempting a connectivity check.
+func SetAPIClient(c *api.Client) {
+	apiClient = c
+}
+
 // EnhancedHealthHandler provides enhanced health check information.
 func EnhancedHealthHandler(w http.ResponseWriter, _ *http.Request) {
 	lastScrape := getLastScrapeTime()
@@ -42,30 +53,15 @@ func EnhancedHealthHandler(w http.ResponseWriter, _ *http.Request) {
 		"uptime_seconds":        getUptimeSeconds(),
 	}
 
-	if tailnet := os.Getenv("TAILNET_NAME"); tailnet != "" {
-		clientID := os.Getenv("OAUTH_CLIENT_ID")
-		token := os.Getenv("OAUTH_TOKEN")
+	if apiClient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 
-		if clientID != "" || token != "" {
-			var apiClient *api.Client
-			if clientID != "" {
-				apiClient = api.NewClient(clientID, os.Getenv("OAUTH_CLIENT_SECRET"), tailnet)
-			} else {
-				apiClient = api.NewClientWithToken(token, tailnet)
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			_, err := apiClient.TestConnectivity(ctx)
-			if err != nil {
-				slog.Warn("API connectivity check failed", "error", err)
-				status["api_status"] = "degraded"
-			} else {
-				status["api_status"] = "healthy"
-			}
+		if _, err := apiClient.TestConnectivity(ctx); err != nil {
+			slog.Warn("API connectivity check failed", "error", err)
+			status["api_status"] = "degraded"
 		} else {
-			status["api_status"] = "not_configured"
+			status["api_status"] = "healthy"
 		}
 	} else {
 		status["api_status"] = "not_configured"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,8 +54,11 @@ func SetupRoutes() *http.ServeMux {
 
 // applySecurityMiddleware wraps the handler with rate limiting, optional token auth,
 // and security headers. A background goroutine cleans up idle rate-limiter entries
-// every 5 minutes for the lifetime of ctx.
-func applySecurityMiddleware(ctx context.Context, handler http.Handler) http.Handler {
+// every 5 minutes for the lifetime of ctx. Returns an error when METRICS_TOKEN is
+// set but fails validation — the caller (main / Run*) is responsible for
+// translating that into a process exit, keeping the exit decision out of the
+// middleware layer so tests can exercise the "weak token rejected" path.
+func applySecurityMiddleware(ctx context.Context, handler http.Handler) (http.Handler, error) {
 	rps := 10.0
 	if v := os.Getenv("RATE_LIMIT_RPS"); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
@@ -91,13 +94,12 @@ func applySecurityMiddleware(ctx context.Context, handler http.Handler) http.Han
 	// /livez, /readyz, and /startupz so Kubernetes probes always pass.
 	//
 	// An operator who sets METRICS_TOKEN obviously wants auth to be enforced —
-	// refusing to start on a weak/malformed token is safer than silently
+	// rejecting a weak/malformed token at startup is safer than silently
 	// accepting it and shipping trivially bypassable protection to production.
 	if token := os.Getenv("METRICS_TOKEN"); token != "" {
 		validator := security.NewInputValidator()
 		if err := validator.ValidateToken(token); err != nil {
-			slog.Error("METRICS_TOKEN rejected — refusing to start with weak auth", "error", err)
-			os.Exit(1)
+			return nil, fmt.Errorf("METRICS_TOKEN rejected: %w", err)
 		}
 		auth := security.NewAuthValidator()
 		auth.AddValidToken(token)
@@ -105,7 +107,7 @@ func applySecurityMiddleware(ctx context.Context, handler http.Handler) http.Han
 		slog.Info("metrics endpoint protected with bearer token authentication")
 	}
 
-	return security.SecurityHeadersMiddleware(h)
+	return security.SecurityHeadersMiddleware(h), nil
 }
 
 // initializeHealthChecker sets up the health checker with appropriate components based on configuration
@@ -144,7 +146,11 @@ func RunStandalone(cfg config.Config, ctx context.Context, collector *metrics.Co
 	slog.Info("HTTP client configured", "network", "standard")
 
 	mux := SetupRoutes()
-	srv := createHTTPServer(addr, applySecurityMiddleware(ctx, mux))
+	handler, err := applySecurityMiddleware(ctx, mux)
+	if err != nil {
+		return err
+	}
+	srv := createHTTPServer(addr, handler)
 
 	// Initialize health checker and background scraper
 	initializeServerComponents(cfg, ctx, collector)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -90,10 +89,19 @@ func applySecurityMiddleware(ctx context.Context, handler http.Handler) http.Han
 	// Token auth is opt-in: set METRICS_TOKEN to require a Bearer token on all
 	// non-probe endpoints. AuthenticationMiddleware whitelists /health, /healthz,
 	// /livez, /readyz, and /startupz so Kubernetes probes always pass.
+	//
+	// An operator who sets METRICS_TOKEN obviously wants auth to be enforced —
+	// refusing to start on a weak/malformed token is safer than silently
+	// accepting it and shipping trivially bypassable protection to production.
 	if token := os.Getenv("METRICS_TOKEN"); token != "" {
-		validator := security.NewAuthValidator()
-		validator.AddValidToken(token)
-		h = security.AuthenticationMiddleware(validator)(h)
+		validator := security.NewInputValidator()
+		if err := validator.ValidateToken(token); err != nil {
+			slog.Error("METRICS_TOKEN rejected — refusing to start with weak auth", "error", err)
+			os.Exit(1)
+		}
+		auth := security.NewAuthValidator()
+		auth.AddValidToken(token)
+		h = security.AuthenticationMiddleware(auth)(h)
 		slog.Info("metrics endpoint protected with bearer token authentication")
 	}
 
@@ -130,12 +138,7 @@ func (s *simpleHealthChecker) CheckHealth(ctx context.Context) error {
 
 // RunStandalone starts the HTTP server in standalone mode.
 func RunStandalone(cfg config.Config, ctx context.Context, collector *metrics.Collector) error {
-	env := strings.ToLower(os.Getenv("ENV"))
-	host := "127.0.0.1" // DevSkim: ignore DS162092 - Localhost binding is intentional for development
-	if env == "production" || env == "prod" {
-		host = "0.0.0.0"
-	}
-	addr := fmt.Sprintf("%s:%s", host, cfg.Port)
+	addr := fmt.Sprintf("%s:%s", cfg.BindHost, cfg.Port)
 
 	metrics.SetHTTPClientProvider(&metrics.StandardHTTPClientProvider{})
 	slog.Info("HTTP client configured", "network", "standard")

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -69,7 +69,10 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 	defer func() { _ = server.Close() }()
 
 	mux := SetupRoutes()
-	handler := applySecurityMiddleware(ctx, mux)
+	handler, err := applySecurityMiddleware(ctx, mux)
+	if err != nil {
+		return err
+	}
 
 	tsHTTPServer := createHTTPServer("", handler) // No Addr for tsnet server
 	tsHTTPServer.Addr = ""                        // Clear Addr for tsnet

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 
 	"tailscale.com/ipn/store"
@@ -18,14 +16,6 @@ import (
 	"github.com/sbaerlocher/tsmetrics/internal/config"
 	"github.com/sbaerlocher/tsmetrics/internal/metrics"
 )
-
-func getLocalBindHost() string {
-	env := strings.ToLower(os.Getenv("ENV"))
-	if env == "production" || env == "prod" {
-		return "0.0.0.0"
-	}
-	return "127.0.0.1" // DevSkim: ignore DS162092 - Localhost binding is intentional for development
-}
 
 func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Collector) error {
 	server := &tsnet.Server{
@@ -84,8 +74,7 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 	tsHTTPServer := createHTTPServer("", handler) // No Addr for tsnet server
 	tsHTTPServer.Addr = ""                        // Clear Addr for tsnet
 
-	host := getLocalBindHost()
-	localAddr := fmt.Sprintf("%s:%s", host, cfg.Port)
+	localAddr := fmt.Sprintf("%s:%s", cfg.BindHost, cfg.Port)
 	localHTTPServer := createHTTPServer(localAddr, handler)
 
 	// Initialize health checker and background scraper
@@ -93,7 +82,7 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 
 	errCh := make(chan error, 2)
 
-	slog.Info("HTTP servers starting", "port", cfg.Port, "local_bind", host)
+	slog.Info("HTTP servers starting", "port", cfg.Port, "local_bind", cfg.BindHost)
 
 	go func() {
 		slog.Info("Tailscale server ready", "bind", ":"+cfg.Port)


### PR DESCRIPTION
## Summary

- **BindHost auto-detection** (`config.resolveBindHost`): inspect `/.dockerenv`, `KUBERNETES_SERVICE_HOST`, and cgroup markers to auto-bind containerized runs on `0.0.0.0` while keeping host-native runs on loopback. `BIND_HOST` env var is an explicit override. Replaces the ENV=production fallback previously duplicated in `server.RunStandalone` and `tsnet.getLocalBindHost`.
- **Reject weak `METRICS_TOKEN`** at startup via `security.ValidateToken`; exit rather than silently shipping bypassable protection. Validator + tests extended for stricter length/character rules.
- **Reuse Tailscale API client** across `/health` probes: `Collector.APIClient()` exposes it, `server.SetAPIClient` stores it, handler reuses the singleton instead of rebuilding an `oauth2.Client` per probe.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (including `internal/security/` tests)
- [ ] Live check `/health` shows `api_status: healthy` without OAuth token churn