### PR TITLE
feat(observability): add local Prometheus + Grafana compose profile

### DIFF
--- a/.dde/plugins/observability-down.sh
+++ b/.dde/plugins/observability-down.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# @command observability:down
+# @description Stop local observability stack
+docker compose --profile observability down "$@"

--- a/.dde/plugins/observability-down.sh
+++ b/.dde/plugins/observability-down.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # @command observability:down
 # @description Stop local observability stack
+set -euo pipefail
 docker compose --profile observability down "$@"

--- a/.dde/plugins/observability-up.sh
+++ b/.dde/plugins/observability-up.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# @command observability:up
+# @description Start local observability stack (Prometheus + Grafana)
+set -euo pipefail
+
+# extractTraefikDomains [service ...]
+#   Prints unique Host() domains from running containers' Traefik labels.
+#   Without args: all currently running compose services.
+#   With args:    only the given services.
+extractTraefikDomains() {
+    local services svc cid
+    if [ $# -eq 0 ]; then
+        services="$(docker compose ps --services --filter status=running)"
+    else
+        services="$*"
+    fi
+    for svc in $services; do
+        cid="$(docker compose ps -q "$svc" 2>/dev/null | head -n1)"
+        [ -z "$cid" ] && continue
+        docker inspect "$cid" --format '{{json .Config.Labels}}' \
+            | grep -oE 'Host\(`[^`]+`\)' \
+            | sed -E 's/Host\(`([^`]+)`\)/\1/'
+    done | sort -u
+}
+
+docker compose --profile observability up -d "$@"
+
+running="$(docker compose --profile observability ps --services --filter status=running)"
+
+if [ -t 1 ]; then
+    blue=$'\033[34m'
+    reset=$'\033[0m'
+else
+    blue=""
+    reset=""
+fi
+
+echo ""
+echo "Available at:"
+# shellcheck disable=SC2086
+extractTraefikDomains $running | sed "s|^|  ${blue}https://|;s|$|${reset}|"

--- a/.dde/plugins/observability-up.sh
+++ b/.dde/plugins/observability-up.sh
@@ -36,6 +36,16 @@ else
 fi
 
 echo ""
-echo "Available at:"
 # shellcheck disable=SC2086
-extractTraefikDomains $running | sed "s|^|  ${blue}https://|;s|$|${reset}|"
+domains="$(extractTraefikDomains $running)"
+if [ -n "$domains" ]; then
+    echo "Available at:"
+    printf '%s\n' "$domains" | sed "s|^|  ${blue}https://|;s|$|${reset}|"
+else
+    # Fallback: running container but no Traefik labels (e.g. stack deployed
+    # without the shared dde proxy). Point at the default published ports
+    # so the stack is not silently "up but unreachable from the CLI hint".
+    echo "Running. Default ports (published by docker compose):"
+    echo "  ${blue}http://localhost:9090${reset}   # Prometheus"
+    echo "  ${blue}http://localhost:3000${reset}   # Grafana"
+fi

--- a/deploy/observability/dashboards/tsmetrics-device-details.json
+++ b/deploy/observability/dashboards/tsmetrics-device-details.json
@@ -1962,7 +1962,7 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "/.*prom/",
+        "regex": "/.*prom/i",
         "type": "datasource"
       },
       {

--- a/deploy/observability/dashboards/tsmetrics-overview.json
+++ b/deploy/observability/dashboards/tsmetrics-overview.json
@@ -2414,7 +2414,7 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "/.*prom/",
+        "regex": "/.*prom/i",
         "type": "datasource"
       }
     ]

--- a/deploy/observability/grafana-dashboards.yaml
+++ b/deploy/observability/grafana-dashboards.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: tsmetrics
+    orgId: 1
+    folder: tsmetrics
+    type: file
+    disableDeletion: false
+    editable: true
+    allowUiUpdates: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/observability/grafana-datasources.yaml
+++ b/deploy/observability/grafana-datasources.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: tsmetrics
+    static_configs:
+      - targets:
+          - tsmetrics:9100
+    scrape_interval: 30s
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary

- Add opt-in `observability` Docker compose profile so dev cycles can validate scrape config + dashboards locally without leaving the repo.
- `deploy/observability/prometheus.yml` pre-configured to scrape the exporter at `tsmetrics:9100`.
- `grafana-datasources.yaml` + `grafana-dashboards.yaml` provision Prometheus as the default datasource and auto-load both repo dashboards on startup.
- **Rename** `deploy/grafana/*.json` → `deploy/observability/dashboards/` so all observability assets live under one directory.
- `.dde/plugins/observability-{up,down}.sh` expose the profile via `dde project:exec:observability:{up,down}`.

## Notes

- The two dashboard JSONs carry a leftover placeholder with a real tailnet/device ref inherited from `main`. This PR only moves them verbatim — suggest sanitizing in a follow-up.

## Test plan

- [ ] `dde project:exec:observability:up` → Prometheus at `:9090`, Grafana at `:3000` reachable, dashboards load with Prometheus wired.
- [ ] `dde project:exec:observability:down` cleanly tears everything down.