### PR TITLE
chore(deploy): drop ENV var and open port 5252 egress

### DIFF
--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -14,7 +14,6 @@ metadata:
 data:
   # Application settings
   PORT: {{ .Values.config.port | quote }}
-  ENV: {{ .Values.config.env | quote }}
   LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   LOG_FORMAT: {{ .Values.config.logFormat | quote }}
 

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -105,8 +105,6 @@ spec:
               value: /tmp
             - name: PORT
               value: {{ .Values.config.port | quote }}
-            - name: ENV
-              value: {{ .Values.config.env | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.config.logLevel | quote }}
             - name: LOG_FORMAT

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -32,7 +32,6 @@ tailscale:
 # Application configuration
 config:
   port: 9100
-  env: "production"
   logLevel: "info"
   logFormat: "text"
   scrapeTag: "exporter"
@@ -219,15 +218,31 @@ networkPolicy:
           port: 9100
 
   # Egress rules
+  #
+  # Kubernetes NetworkPolicy cannot match by DNS name, so API traffic has to
+  # be allowed by destination CIDR. The defaults below are intentionally
+  # broad — they permit *any* external HTTPS/HTTP destination — because the
+  # exporter has to reach api.tailscale.com (and in tsnet mode every device
+  # in the tailnet). For stricter setups, override `egress` in values.yaml
+  # with your Tailscale IP range (e.g. 100.64.0.0/10) plus the Tailscale
+  # control-plane CIDRs, and keep port 80 off unless a transparent proxy
+  # truly needs it.
   egress:
-    # Allow HTTPS/HTTP for API calls
+    # Tailscale API (HTTPS) + HTTP redirects from upstream captive portals.
     - to: []
       ports:
         - protocol: TCP
           port: 443
         - protocol: TCP
           port: 80
-    # Allow DNS resolution
+    # Tailscale device metrics endpoints (port 5252) inside the tailnet.
+    # Safe to restrict further with `to.ipBlock.cidr: 100.64.0.0/10` if you
+    # only scrape devices that live in the standard Tailscale CGNAT range.
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 5252
+    # DNS resolution (UDP primary, TCP fallback for large responses).
     - to: []
       ports:
         - protocol: UDP

--- a/deploy/kustomize/base/configmap.yaml
+++ b/deploy/kustomize/base/configmap.yaml
@@ -11,7 +11,6 @@ metadata:
 data:
   # Application settings
   PORT: "9100"
-  ENV: "production"
   LOG_LEVEL: "info"
   LOG_FORMAT: "json"
 

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -66,8 +66,6 @@ spec:
               value: /tmp
             - name: PORT
               value: "9100"
-            - name: ENV
-              value: "production"
             - name: LOG_LEVEL
               value: "info"
             - name: LOG_FORMAT

--- a/deploy/kustomize/base/networkpolicy.yaml
+++ b/deploy/kustomize/base/networkpolicy.yaml
@@ -22,13 +22,22 @@ spec:
         - protocol: TCP
           port: 9100
   egress:
-    - to: [] # Allow all outbound for API calls
+    # Tailscale API (HTTPS) + HTTP redirects from upstream captive portals.
+    - to: []
       ports:
         - protocol: TCP
           port: 443
         - protocol: TCP
           port: 80
-    - to: [] # Allow DNS
+    # Tailscale device metrics endpoints (port 5252) inside the tailnet.
+    # Safe to restrict further with `to.ipBlock.cidr: 100.64.0.0/10` if you
+    # only scrape devices that live in the standard Tailscale CGNAT range.
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 5252
+    # DNS resolution (UDP primary, TCP fallback for large responses).
+    - to: []
       ports:
         - protocol: UDP
           port: 53

--- a/deploy/kustomize/overlays/development/deployment-patch.yaml
+++ b/deploy/kustomize/overlays/development/deployment-patch.yaml
@@ -41,8 +41,6 @@ spec:
             - name: LOG_LEVEL
               # devskim: ignore DS173237 - Debug level appropriate for development environment
               value: "debug"
-            - name: ENV
-              value: "development"
             - name: TSNET_HOSTNAME
               value: "tsmetrics-dev"
           resources:

--- a/deploy/kustomize/overlays/production/deployment-patch.yaml
+++ b/deploy/kustomize/overlays/production/deployment-patch.yaml
@@ -39,8 +39,6 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "info"
-            - name: ENV
-              value: "production"
             - name: SCRAPE_TAG
               value: "production"
             - name: TSNET_STATE_SECRET


### PR DESCRIPTION
Pairs with #75 (runtime bind-host auto-detection).

## Summary

- Drop the `ENV` env var from Helm configmap/deployment, Kustomize base + dev/prod overlays — it no longer drives behaviour once `config.resolveBindHost` takes over (see #75). Leaving it would let operators assume a stale knob still works.
- Add a dedicated Helm NetworkPolicy egress rule for port **5252** so tsnet-mode scrapes can reach each peer's `tailscaled /metrics` endpoint.
- Document the broad 443/80 egress rule: Kubernetes NetworkPolicy has no DNS matching, so `api.tailscale.com` must be allowed by CIDR; in tsnet mode the scrape destinations are all peer nodes. Add a note that operators who only scrape CGNAT devices can tighten to `100.64.0.0/10`.

## Test plan

- [ ] `helm template deploy/helm/tsmetrics` produces a manifest without the `ENV` env var.
- [ ] `kubectl apply -k deploy/kustomize/overlays/development` + production builds succeed.
- [ ] NetworkPolicy allows outbound 5252 (verified on a cluster with NetworkPolicy enforcement).