### PR TITLE
chore(dev): add lefthook config for pre-commit and pre-push hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,15 @@ Project config lives in `.dde/config.yml`; compose stack in `docker-compose.yml`
 
 Bootstrap (one-time per machine): `brew tap whatwedo/tap && brew install dde && dde system:up`.
 
+Optional git hooks via [lefthook](https://lefthook.dev) — install once with
+`brew install lefthook && lefthook install`. Pre-commit auto-formats staged Go
+files (`gofmt -w` + `stage_fixed`), runs full-project `golangci-lint`, and
+`markdownlint`/`yamllint`/`shellcheck` on the matching staged files. Pre-push
+runs `go test` over `./internal/... ./pkg/... ./cmd/... ./tests/integration/...
+./tests/structure/...` — the 45 s `tests/load` stress sweep is intentionally
+left to CI. Host-native tooling, no container required. Skip with
+`LEFTHOOK=0 git commit` or `--no-verify`. Config in `lefthook.yml`.
+
 just recipes (`just` to list):
 
 - `just dev` — start dev container + tail logs

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,48 @@
+# Git hooks managed by lefthook (https://lefthook.dev).
+# Run host-native tooling (go, golangci-lint, markdownlint, yamllint,
+# shellcheck) as a fast safety net before commit/push. The dde + just
+# container flow remains the canonical CI path; lefthook is opt-in and
+# can be skipped with `LEFTHOOK=0 git commit` or `--no-verify`.
+#
+# Install locally with: `brew install lefthook && lefthook install`
+---
+pre-commit:
+  parallel: true
+  commands:
+    # Auto-format and re-stage. Avoids the working-tree-vs-index mismatch
+    # of `gofmt -l` and removes the "block, run `go fmt`, retry" round-trip.
+    gofmt:
+      glob: '*.go'
+      run: gofmt -w {staged_files}
+      stage_fixed: true
+
+    # Full-project lint via .golangci.yml (govet + gosec included).
+    # The glob only gates *whether* the hook runs (skip on non-Go commits);
+    # the lint itself analyses the entire module to catch cross-file
+    # regressions that a staged-subset run would miss.
+    golangci-lint:
+      glob: '*.go'
+      run: golangci-lint run
+
+    markdownlint:
+      glob: '*.md'
+      run: markdownlint {staged_files}
+
+    yamllint:
+      glob: '*.{yml,yaml}'
+      run: yamllint {staged_files}
+
+    shellcheck:
+      glob: '*.sh'
+      run: shellcheck {staged_files}
+
+pre-push:
+  commands:
+    # Unit + integration + structure suites. The 45 s tests/load stress
+    # sweep is intentionally excluded from local pushes — it gates merges
+    # in CI but is too slow to run on every push.
+    test:
+      run: >
+        go test
+        ./internal/... ./pkg/... ./cmd/...
+        ./tests/integration/... ./tests/structure/...


### PR DESCRIPTION
## Summary

Add a host-native git hook setup as a fast safety net before commit and push. The dde + just container flow remains the canonical CI path; lefthook is opt-in (`brew install lefthook && lefthook install`) and can be skipped with `LEFTHOOK=0` or `--no-verify`.

### pre-commit (parallel, only staged files)

- `gofmt` — refuses the commit if any staged Go file is unformatted, with a `go fmt ./...` hint
- `golangci-lint` — full project lint via the existing `.golangci.yml` (covers govet + gosec)
- `markdownlint` / `yamllint` / `shellcheck` — glob-scoped, so a Go-only change does not run unrelated linters

### pre-push

- `go test ./internal/... ./pkg/... ./cmd/...` — unit + integration suites; the 45 s `tests/load` sweep stays in CI

`AGENTS.md` grows a short section under the build system pointing at install, scope, and the `LEFTHOOK=0` escape hatch.

## Test plan

- [ ] `brew install lefthook && lefthook install` registers the hooks
- [ ] Commit a Go file with bad formatting → blocked with `go fmt ./...` hint
- [ ] Commit a clean change → all hooks pass in parallel
- [ ] `LEFTHOOK=0 git commit` bypasses the hooks