### PR TITLE
chore(deps): bump .github workflows to 2026-06-08

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   code-analysis:
     name: SAST (CodeQL)
-    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-05-30
+    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-06-08
     with:
       languages: '["go"]'
       go-version: "1.26"
@@ -23,7 +23,7 @@ jobs:
 
   dependency-scan:
     name: Dependencies & Licenses
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-05-30
+    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-06-08
     with:
       language: "go"
       enable-license-check: true
@@ -31,13 +31,13 @@ jobs:
 
   secret-detection:
     name: Secret Detection
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-05-30
+    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-06-08
     with:
       concurrency-suffix: secrets
 
   container-scan:
     name: Container Security
-    uses: sbaerlocher/.github/.github/workflows/security-containers.yml@2026-05-30
+    uses: sbaerlocher/.github/.github/workflows/security-containers.yml@2026-06-08
     with:
       image-ref: "ghcr.io/${{ github.repository }}:latest"
       concurrency-suffix: containers


### PR DESCRIPTION
## Summary

Bumps all reusable workflow references from `@2026-05-30` to `@2026-06-08`.

The new tag includes the fix for the `go-licenses` v2 module path (`github.com/google/go-licenses/v2`), which caused the weekly Security Scan to fail on the "Dependencies & Licenses / Audit Go" job since the v2.0.1 version was pinned.

## Test plan

- [ ] Merge and verify next Monday's Security Scan passes completely