### PR TITLE
fix(helm): wire METRICS_TOKEN into chart to protect /metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ tsmetrics operates in two phases:
 - **Connection Pooling**: Reuses HTTP connections for efficiency
 - **Concurrent Scraping**: Parallel device metrics collection
 - **Memory Management**: Automatic cleanup of stale device metrics
-- **Circuit Breaker**: Protects against API failures (planned)
+- **API Resilience**: Retry with exponential backoff + jitter, request timeouts, and graceful fallback to the configured device list on Tailscale API failure
 
 ### High Availability
 

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -169,6 +169,13 @@ spec:
                   name: {{ include "tsmetrics.fullname" . }}-secrets
                   key: TS_AUTHKEY
 {{- end }}
+{{- if .Values.tailscale.metricsToken }}
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tsmetrics.fullname" . }}-secrets
+                  key: METRICS_TOKEN
+{{- end }}
 {{- end }}
 {{- if .Values.externalSecret.enabled }}
           envFrom:

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -12,4 +12,7 @@ stringData:
   {{- if .Values.tailscale.tsnet.authKey }}
   TS_AUTHKEY: {{ .Values.tailscale.tsnet.authKey | quote }}
   {{- end }}
+  {{- if .Values.tailscale.metricsToken }}
+  METRICS_TOKEN: {{ .Values.tailscale.metricsToken | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -21,6 +21,12 @@ tailscale:
   oauthClientSecret: ""
   tailnetName: ""
 
+  # Bearer token protecting /metrics and /debug (recommended in shared clusters).
+  # /metrics exposes device_user{user_email}, NodeKeys and external IPs — leave
+  # empty only when network-level controls (NetworkPolicy) already isolate the
+  # endpoint. Min 20 chars, alphanumeric + -._ (server exits if set but invalid).
+  metricsToken: ""
+
   # tsnet configuration
   tsnet:
     enabled: true
@@ -76,6 +82,7 @@ externalSecret:
     oauthClientSecret: "OAUTH_CLIENT_SECRET"
     tailnetName: "TAILNET_NAME"
     authKey: "TS_AUTHKEY" # optional
+    metricsToken: "METRICS_TOKEN" # optional
 
 # Pod configuration
 podAnnotations: {}


### PR DESCRIPTION
## Summary

- The exporter enforces Bearer auth on `/metrics` when `METRICS_TOKEN` is set (`internal/server/server.go`), but the Helm chart never bound the variable — so Helm deployments exposed `/metrics` (incl. `tailscale_device_user{user_email}`, NodeKeys, external IPs) **unauthenticated**. (P0, from Notion audit)
- Add `tailscale.metricsToken` value → flows into the chart Secret + container env via `secretKeyRef`, plus an `externalSecret.keys.metricsToken` mapping for the ExternalSecret path. Opt-in (empty default), matching the OAuth wiring.
- Correct the README performance section: the API client already does retry + exponential backoff + jitter, timeouts and graceful fallback — drop the stale "Circuit Breaker (planned)" line.

## Test plan

- [ ] CI: Helm lint + render (helm-test job) green
- [ ] `helm template . --set tailscale.metricsToken=<token>` renders `METRICS_TOKEN` in both Secret stringData and the container env
- [ ] Empty `metricsToken` (default) renders no `METRICS_TOKEN` (no regression)

## Context

From the "Repo Ideas" Notion audit. Three sibling findings were verified as not-actionable and closed there: tsnet-State RBAC (already correctly scoped), Circuit-Breaker (already implemented as retry/backoff/fallback), osv-scanner (govulncheck already covers Go SCA).