### PR TITLE
refactor(server): retry kube state store creation on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Kubernetes state store creation now retries with exponential backoff for
+  roughly 90s on startup. A transient API server outage previously killed the
+  process immediately, leaving the pod in CrashLoopBackOff even after the API
+  server recovered. A permanently unreachable API server still surfaces as a
+  CrashLoopBackOff once the attempts are exhausted.
+
+### Changed
+
+- `WithJitter` moved from `internal/api/client.go` to `internal/errors` so both
+  the API retry loop and the new startup retry share one implementation.
+
 ## [1.2.0] - 2026-04-24
 
 ### Added

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"strings"
@@ -194,7 +193,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, url, endpoint string) 
 	var retryAfter time.Duration
 	for attempt := 0; attempt < retryCfg.MaxAttempts; attempt++ {
 		if attempt > 0 {
-			delay := withJitter(retryCfg.CalculateDelay(attempt - 1))
+			delay := tserrors.WithJitter(retryCfg.CalculateDelay(attempt - 1))
 			if retryAfter > delay {
 				delay = retryAfter
 			}
@@ -240,30 +239,6 @@ func (c *Client) doWithRetry(ctx context.Context, method, url, endpoint string) 
 		return nil, fmt.Errorf("request failed after %d attempts: %w", retryCfg.MaxAttempts, lastErr)
 	}
 	return nil, fmt.Errorf("request failed after %d attempts: last status %d", retryCfg.MaxAttempts, lastStatus)
-}
-
-// withJitter adds a random ±25% jitter to d so concurrent clients stop
-// synchronising on a recovering upstream. Negative jitter is clamped to zero.
-func withJitter(d time.Duration) time.Duration {
-	if d <= 0 {
-		return d
-	}
-	// Half-range: each side of the interval is 25% of d.
-	halfRange := int64(d) / 4
-	if halfRange == 0 {
-		return d
-	}
-	// rand.Int64N is safe for concurrent use (Go 1.22+) and suitable here —
-	// retry pacing does not need crypto-grade randomness and the jittered
-	// delay is not security-sensitive.
-	//
-	// #nosec G404 -- non-crypto RNG is appropriate for retry backoff jitter
-	offset := rand.Int64N(2*halfRange+1) - halfRange //nolint:gosec // G404: see comment above
-	jittered := int64(d) + offset
-	if jittered < 0 {
-		return 0
-	}
-	return time.Duration(jittered)
 }
 
 // parseRetryAfter parses the Retry-After header value. The header may be a

--- a/internal/api/client_retry_test.go
+++ b/internal/api/client_retry_test.go
@@ -183,21 +183,3 @@ func TestParseRetryAfter(t *testing.T) {
 		t.Errorf("parseRetryAfter(past) = %v, want 0", got)
 	}
 }
-
-func TestWithJitter_BoundsAndZero(t *testing.T) {
-	if got := withJitter(0); got != 0 {
-		t.Errorf("withJitter(0) = %v, want 0", got)
-	}
-	// Single-ns durations have a zero half-range and must round-trip.
-	if got := withJitter(time.Nanosecond); got != time.Nanosecond {
-		t.Errorf("withJitter(1ns) = %v, want 1ns", got)
-	}
-	// Bulk test: 1000 samples must all fall within ±25% of 400ms.
-	base := 400 * time.Millisecond
-	for range 1000 {
-		got := withJitter(base)
-		if got < 300*time.Millisecond || got > 500*time.Millisecond {
-			t.Fatalf("withJitter(%v) = %v out of ±25%% bounds", base, got)
-		}
-	}
-}

--- a/internal/errors/jitter.go
+++ b/internal/errors/jitter.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// WithJitter adds a random ±25% jitter to d so concurrent clients stop
+// synchronising on a recovering upstream. Negative jitter is clamped to zero.
+func WithJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	// Half-range: each side of the interval is 25% of d.
+	halfRange := int64(d) / 4
+	if halfRange == 0 {
+		return d
+	}
+	// rand.Int64N is safe for concurrent use (Go 1.22+) and suitable here —
+	// retry pacing does not need crypto-grade randomness and the jittered
+	// delay is not security-sensitive.
+	//
+	// #nosec G404 -- non-crypto RNG is appropriate for retry backoff jitter
+	offset := rand.Int64N(2*halfRange+1) - halfRange //nolint:gosec // G404: see comment above
+	jittered := int64(d) + offset
+	if jittered < 0 {
+		return 0
+	}
+	return time.Duration(jittered)
+}

--- a/internal/errors/jitter_test.go
+++ b/internal/errors/jitter_test.go
@@ -1,0 +1,24 @@
+package errors
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithJitter_BoundsAndZero(t *testing.T) {
+	if got := WithJitter(0); got != 0 {
+		t.Errorf("WithJitter(0) = %v, want 0", got)
+	}
+	// Single-ns durations have a zero half-range and must round-trip.
+	if got := WithJitter(time.Nanosecond); got != time.Nanosecond {
+		t.Errorf("WithJitter(1ns) = %v, want 1ns", got)
+	}
+	// Bulk test: 1000 samples must all fall within ±25% of 400ms.
+	base := 400 * time.Millisecond
+	for range 1000 {
+		got := WithJitter(base)
+		if got < 300*time.Millisecond || got > 500*time.Millisecond {
+			t.Fatalf("WithJitter(%v) = %v out of ±25%% bounds", base, got)
+		}
+	}
+}

--- a/internal/errors/types.go
+++ b/internal/errors/types.go
@@ -121,6 +121,22 @@ func DefaultRetryConfig() RetryConfig {
 	}
 }
 
+// StartupRetryConfig returns a retry configuration for startup-time
+// dependencies that may briefly be unavailable while the surrounding platform
+// comes up (for example a Kubernetes API server that is still restarting).
+// It is deliberately more patient than DefaultRetryConfig: the summed delays
+// span roughly 91s without jitter, which bridges a short outage while still
+// letting the process exit — and stay visible as a CrashLoopBackOff — when the
+// dependency is permanently gone.
+func StartupRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts: 8,
+		BaseDelay:   1 * time.Second,
+		MaxDelay:    30 * time.Second,
+		Multiplier:  2.0,
+	}
+}
+
 // CalculateDelay calculates the delay for the given retry attempt.
 func (rc RetryConfig) CalculateDelay(attempt int) time.Duration {
 	if attempt <= 0 {

--- a/internal/errors/types_test.go
+++ b/internal/errors/types_test.go
@@ -129,3 +129,30 @@ func TestDeviceError(t *testing.T) {
 		t.Error("Unwrap() should return underlying error")
 	}
 }
+
+func TestStartupRetryConfig(t *testing.T) {
+	rc := StartupRetryConfig()
+
+	if rc.MaxAttempts != 8 {
+		t.Errorf("MaxAttempts = %d, want 8", rc.MaxAttempts)
+	}
+	if rc.BaseDelay != 1*time.Second {
+		t.Errorf("BaseDelay = %v, want 1s", rc.BaseDelay)
+	}
+	if rc.MaxDelay != 30*time.Second {
+		t.Errorf("MaxDelay = %v, want 30s", rc.MaxDelay)
+	}
+	if rc.Multiplier != 2.0 {
+		t.Errorf("Multiplier = %v, want 2.0", rc.Multiplier)
+	}
+
+	// The startup budget must bridge a short API server restart without
+	// hanging silently on a permanent outage.
+	var total time.Duration
+	for attempt := range rc.MaxAttempts - 1 {
+		total += rc.CalculateDelay(attempt)
+	}
+	if total < 60*time.Second || total > 180*time.Second {
+		t.Errorf("summed startup delay = %v, want between 60s and 180s", total)
+	}
+}

--- a/internal/server/statestore.go
+++ b/internal/server/statestore.go
@@ -25,6 +25,13 @@ type storeFactory func(logger.Logf, string) (ipn.StateStore, error)
 // propagated, the process exits and Kubernetes restarts the pod. A permanently
 // unreachable API server therefore stays visible as a CrashLoopBackOff instead
 // of silently hanging.
+//
+// Every failure is treated as transient. Permanent ones — missing RBAC rights
+// on the Secret, or running outside a cluster — therefore burn the full budget
+// before the process exits. That costs roughly 90s per restart and is accepted
+// deliberately: the failures are indistinguishable from a transient outage at
+// this layer without parsing driver-specific error strings, and the retry only
+// runs once per process start.
 func newStateStoreWithRetry(ctx context.Context, logf logger.Logf, path string, factory storeFactory) (ipn.StateStore, error) {
 	return newStateStoreWithRetryConfig(ctx, logf, path, factory, tserrors.StartupRetryConfig())
 }
@@ -38,14 +45,14 @@ func newStateStoreWithRetryConfig(ctx context.Context, logf logger.Logf, path st
 		// Checked before every attempt, including the first: a context that is
 		// already cancelled must not reach the factory at all.
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("state store creation cancelled after %d attempts: %w", attempt, err)
+			return nil, fmt.Errorf("state store creation cancelled before attempt %d: %w", attempt+1, err)
 		}
 
 		if attempt > 0 {
 			delay := tserrors.WithJitter(retryCfg.CalculateDelay(attempt - 1))
 			select {
 			case <-ctx.Done():
-				return nil, fmt.Errorf("state store creation cancelled after %d attempts: %w", attempt, ctx.Err())
+				return nil, fmt.Errorf("state store creation cancelled while waiting to retry after %d attempts: %w", attempt, ctx.Err())
 			case <-time.After(delay):
 			}
 		}
@@ -66,5 +73,10 @@ func newStateStoreWithRetryConfig(ctx context.Context, logf logger.Logf, path st
 			"error", err)
 	}
 
-	return nil, fmt.Errorf("failed to create state store after %d attempts: %w", retryCfg.MaxAttempts, lastErr)
+	if lastErr == nil {
+		// Only reachable with a non-positive MaxAttempts, where the loop never
+		// ran; without this the %w below would render as %!w(<nil>).
+		return nil, fmt.Errorf("failed to create state store %q: no attempts made (MaxAttempts=%d)", path, retryCfg.MaxAttempts)
+	}
+	return nil, fmt.Errorf("failed to create state store %q after %d attempts: %w", path, retryCfg.MaxAttempts, lastErr)
 }

--- a/internal/server/statestore.go
+++ b/internal/server/statestore.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"tailscale.com/ipn"
+	"tailscale.com/types/logger"
+
+	tserrors "github.com/sbaerlocher/tsmetrics/internal/errors"
+)
+
+// storeFactory creates a state store for the given path. In production this is
+// tailscale.com/ipn/store.New; tests inject a stub.
+type storeFactory func(logger.Logf, string) (ipn.StateStore, error)
+
+// newStateStoreWithRetry creates the state store, retrying transient failures
+// with exponential backoff. A Kubernetes API server that is briefly unreachable
+// while it restarts would otherwise kill the process on startup, and the pod
+// could not recover on its own once the API server came back.
+//
+// After the attempts are exhausted the original behaviour returns: the error is
+// propagated, the process exits and Kubernetes restarts the pod. A permanently
+// unreachable API server therefore stays visible as a CrashLoopBackOff instead
+// of silently hanging.
+func newStateStoreWithRetry(ctx context.Context, logf logger.Logf, path string, factory storeFactory) (ipn.StateStore, error) {
+	return newStateStoreWithRetryConfig(ctx, logf, path, factory, tserrors.StartupRetryConfig())
+}
+
+// newStateStoreWithRetryConfig is newStateStoreWithRetry with an injectable
+// retry configuration so tests can exercise the loop without waiting out the
+// full startup budget.
+func newStateStoreWithRetryConfig(ctx context.Context, logf logger.Logf, path string, factory storeFactory, retryCfg tserrors.RetryConfig) (ipn.StateStore, error) {
+	var lastErr error
+	for attempt := range retryCfg.MaxAttempts {
+		// Checked before every attempt, including the first: a context that is
+		// already cancelled must not reach the factory at all.
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("state store creation cancelled after %d attempts: %w", attempt, err)
+		}
+
+		if attempt > 0 {
+			delay := tserrors.WithJitter(retryCfg.CalculateDelay(attempt - 1))
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("state store creation cancelled after %d attempts: %w", attempt, ctx.Err())
+			case <-time.After(delay):
+			}
+		}
+
+		stateStore, err := factory(logf, path)
+		if err == nil {
+			if attempt > 0 {
+				slog.Info("state store created after retry", "attempts", attempt+1)
+			}
+			return stateStore, nil
+		}
+
+		lastErr = err
+		slog.Warn("state store creation failed",
+			"attempt", attempt+1,
+			"max_attempts", retryCfg.MaxAttempts,
+			"will_retry", attempt < retryCfg.MaxAttempts-1,
+			"error", err)
+	}
+
+	return nil, fmt.Errorf("failed to create state store after %d attempts: %w", retryCfg.MaxAttempts, lastErr)
+}

--- a/internal/server/statestore_test.go
+++ b/internal/server/statestore_test.go
@@ -51,8 +51,17 @@ func TestNewStateStoreWithRetry_SucceedsFirstAttempt(t *testing.T) {
 }
 
 func TestNewStateStoreWithRetry_SucceedsSecondAttempt(t *testing.T) {
+	// Fast config: the production one would really sleep ~1s before retry 2.
+	fastCfg := tserrors.RetryConfig{
+		MaxAttempts: 8,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    2 * time.Millisecond,
+		Multiplier:  2.0,
+	}
+
 	calls := 0
-	store, err := newStateStoreWithRetry(context.Background(), discardLogf, "kube:test", failingFactory(1, &calls))
+	store, err := newStateStoreWithRetryConfig(context.Background(), discardLogf, "kube:test",
+		failingFactory(1, &calls), fastCfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -100,10 +109,19 @@ func TestNewStateStoreWithRetry_StopsDuringBackoff(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	calls := 0
 	factory := func(logger.Logf, string) (ipn.StateStore, error) {
 		calls++
-		cancel() // fail, then cancel while the wrapper waits to retry
+		// Cancel asynchronously so the wrapper has already entered the select
+		// on time.After. Cancelling inline would instead be caught by the
+		// top-of-loop ctx.Err() guard, leaving the select's ctx.Done() arm —
+		// the one that matters for SIGTERM mid-backoff — untested.
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
 		return nil, errors.New("connection refused")
 	}
 

--- a/internal/server/statestore_test.go
+++ b/internal/server/statestore_test.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"tailscale.com/ipn"
+	"tailscale.com/types/logger"
+
+	tserrors "github.com/sbaerlocher/tsmetrics/internal/errors"
+)
+
+// discardLogf drops tsnet log output during tests.
+func discardLogf(string, ...any) {}
+
+// stubStore is a minimal ipn.StateStore standing in for the kube store. The
+// retry wrapper never touches the store's contents, so the methods are inert.
+type stubStore struct{}
+
+func (stubStore) ReadState(ipn.StateKey) ([]byte, error) { return nil, ipn.ErrStateNotExist }
+
+func (stubStore) WriteState(ipn.StateKey, []byte) error { return nil }
+
+// failingFactory returns an error for the first failures calls, then succeeds.
+// It records how many times it was invoked.
+func failingFactory(failures int, calls *int) storeFactory {
+	return func(logger.Logf, string) (ipn.StateStore, error) {
+		*calls++
+		if *calls <= failures {
+			return nil, errors.New("connection refused")
+		}
+		return stubStore{}, nil
+	}
+}
+
+func TestNewStateStoreWithRetry_SucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	store, err := newStateStoreWithRetry(context.Background(), discardLogf, "kube:test", failingFactory(0, &calls))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store == nil {
+		t.Fatal("expected a state store, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("factory called %d times, want 1", calls)
+	}
+}
+
+func TestNewStateStoreWithRetry_SucceedsSecondAttempt(t *testing.T) {
+	calls := 0
+	store, err := newStateStoreWithRetry(context.Background(), discardLogf, "kube:test", failingFactory(1, &calls))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store == nil {
+		t.Fatal("expected a state store, got nil")
+	}
+	if calls != 2 {
+		t.Errorf("factory called %d times, want 2", calls)
+	}
+}
+
+func TestNewStateStoreWithRetry_ExhaustsAttempts(t *testing.T) {
+	// A fast config keeps the test quick; the real startup budget is asserted
+	// in TestStartupRetryConfig.
+	fastCfg := tserrors.RetryConfig{
+		MaxAttempts: 4,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    2 * time.Millisecond,
+		Multiplier:  2.0,
+	}
+
+	calls := 0
+	_, err := newStateStoreWithRetryConfig(context.Background(), discardLogf, "kube:test",
+		failingFactory(fastCfg.MaxAttempts, &calls), fastCfg)
+	if err == nil {
+		t.Fatal("expected an error when every attempt fails")
+	}
+	if calls != fastCfg.MaxAttempts {
+		t.Errorf("factory called %d times, want exactly %d", calls, fastCfg.MaxAttempts)
+	}
+	// The underlying failure must stay inspectable by the caller.
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error %q does not wrap the underlying failure", err)
+	}
+}
+
+func TestNewStateStoreWithRetry_StopsDuringBackoff(t *testing.T) {
+	// Long delays guarantee the cancel lands while the loop waits between
+	// attempts rather than before the first one.
+	slowCfg := tserrors.RetryConfig{
+		MaxAttempts: 5,
+		BaseDelay:   10 * time.Second,
+		MaxDelay:    10 * time.Second,
+		Multiplier:  2.0,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	factory := func(logger.Logf, string) (ipn.StateStore, error) {
+		calls++
+		cancel() // fail, then cancel while the wrapper waits to retry
+		return nil, errors.New("connection refused")
+	}
+
+	start := time.Now()
+	_, err := newStateStoreWithRetryConfig(ctx, discardLogf, "kube:test", factory, slowCfg)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when the context is cancelled mid-backoff")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Errorf("factory called %d times, want 1", calls)
+	}
+	// Must abort the wait rather than sleep out the full backoff.
+	if elapsed > 5*time.Second {
+		t.Errorf("took %v, want an immediate abort on cancel", elapsed)
+	}
+}
+
+func TestNewStateStoreWithRetry_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	_, err := newStateStoreWithRetry(ctx, discardLogf, "kube:test", failingFactory(99, &calls))
+	if err == nil {
+		t.Fatal("expected an error when the context is cancelled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+	// An already-cancelled context must short-circuit before the factory runs.
+	if calls != 0 {
+		t.Errorf("factory called %d times, want 0", calls)
+	}
+}

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -31,6 +31,12 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 		}
 		stateStore, err := newStateStoreWithRetry(ctx, logf, "kube:"+cfg.TsnetStateSecret, store.New)
 		if err != nil {
+			// A shutdown signal during the retry window is a clean exit, not a
+			// failure — the same as the ctx.Done() path further down.
+			if ctx.Err() != nil {
+				slog.Info("state store creation aborted by shutdown", "error", err)
+				return nil
+			}
 			return err
 		}
 		server.Store = stateStore

--- a/internal/server/tsnet.go
+++ b/internal/server/tsnet.go
@@ -29,9 +29,9 @@ func RunWithTsnet(cfg config.Config, ctx context.Context, collector *metrics.Col
 		logf := func(format string, args ...any) {
 			slog.Debug(fmt.Sprintf(format, args...))
 		}
-		stateStore, err := store.New(logf, "kube:"+cfg.TsnetStateSecret)
+		stateStore, err := newStateStoreWithRetry(ctx, logf, "kube:"+cfg.TsnetStateSecret, store.New)
 		if err != nil {
-			return fmt.Errorf("failed to create kube state store: %w", err)
+			return err
 		}
 		server.Store = stateStore
 		slog.Info("tsnet using Kubernetes Secret as state store", "secret", cfg.TsnetStateSecret)


### PR DESCRIPTION
## Summary

- Wrap `store.New` in a retry loop with exponential backoff (~91s) so a transient Kubernetes API server outage no longer kills the process on startup. The pod previously stayed in CrashLoopBackOff even after the API server recovered, and only a manual pod delete brought it back.
- After the attempts are exhausted the previous behaviour returns: the error propagates and the process exits, so a permanently unreachable API server stays visible as a CrashLoopBackOff instead of hanging silently. Every failure is treated as transient, so a permanent one (RBAC denial, running outside a cluster) burns the full budget once per process start — noted explicitly in the doc comment.
- A shutdown signal during the retry window is treated as a clean exit, so SIGTERM mid-backoff does not newly log at ERROR.
- Move `withJitter` from `internal/api/client.go` to `internal/errors` as the exported `WithJitter`, so the API retry loop and the new startup retry share one implementation.

## Test plan

- [ ] CI green (`go test ./...`, golangci-lint) — the Go toolchain and linters were unavailable in the build sandbox, so everything below is verified in CI, not locally.
- [ ] `TestStartupRetryConfig` asserts the config values and that the summed backoff (91s) stays within 60s–180s.
- [ ] `TestNewStateStoreWithRetry_*` cover success on the first attempt, success on the second, exhaustion after exactly `MaxAttempts`, an already-cancelled context (factory never invoked), and cancellation *during* backoff. The last one cancels asynchronously so it genuinely exercises the `select`'s `ctx.Done()` arm rather than the top-of-loop guard.
- [ ] `TestWithJitter_BoundsAndZero` moved to `internal/errors` unchanged in substance.