### PR TITLE
docs: cut 1.3.0 changelog and fix the CI badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server recovered. A permanently unreachable API server still surfaces as a
   CrashLoopBackOff once the attempts are exhausted.
 
+### Changed
+
+- `WithJitter` moved from `internal/api/client.go` to `internal/errors` so both
+  the API retry loop and the new startup retry share one implementation.
+
 ### Security
 
 - Helm chart wires `METRICS_TOKEN` through the chart Secret and container env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-04
+
+### Added
+
+- `deploy/observability/alerts.yml`: 8 Prometheus alerting rules over the
+  exporter's own health (down, stale scrape, scrape errors) and the tailnet
+  (device offline, machine-key expiry, high DERP latency, tailnet-lock error,
+  health messages), wired via `rule_files` in `prometheus.yml`.
+- Releases ship a syft SPDX SBOM plus keyless cosign signing of
+  `checksums.txt`, so consumers can verify the published artifacts.
+
 ### Fixed
 
 - Kubernetes state store creation now retries with exponential backoff for
@@ -15,10 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server recovered. A permanently unreachable API server still surfaces as a
   CrashLoopBackOff once the attempts are exhausted.
 
-### Changed
+### Security
 
-- `WithJitter` moved from `internal/api/client.go` to `internal/errors` so both
-  the API retry loop and the new startup retry share one implementation.
+- Helm chart wires `METRICS_TOKEN` through the chart Secret and container env
+  (`tailscale.metricsToken`, plus an ExternalSecret key mapping). The exporter
+  enforces Bearer auth on `/metrics` when the variable is set, but the chart
+  never bound it, so Helm deployments exposed `/metrics` — including
+  `device_user{user_email}`, NodeKeys and external IPs — unauthenticated.
+  Empty by default (opt-in), matching the OAuth wiring; operators who want
+  the endpoint protected must set the value.
+
+### Dependencies
+
+- Bump Go toolchain, `prom/prometheus`, `prometheus/client_golang`,
+  `grafana/grafana` digest, `sbaerlocher/.github` action and presets to
+  v2026-08-03, plus non-major transitive bumps via Renovate.
 
 ## [1.2.0] - 2026-04-24
 
@@ -338,6 +360,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kustomize overlays for environment-specific configurations
 - Comprehensive health checks and monitoring endpoints
 
+[Unreleased]: https://github.com/sbaerlocher/tsmetrics/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/sbaerlocher/tsmetrics/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/sbaerlocher/tsmetrics/compare/v1.1.0...v1.1.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Tailscale Prometheus exporter that combines API metadata with li
 
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://golang.org/)
 [![Docker](https://img.shields.io/badge/Docker-Available-2496ED?style=flat&logo=docker)](https://ghcr.io/sbaerlocher/tsmetrics)
-[![CI](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml/badge.svg)](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml)
+[![CI](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml/badge.svg?event=pull_request)](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sbaerlocher/tsmetrics)](https://goreportcard.com/report/github.com/sbaerlocher/tsmetrics)
 [![Release](https://img.shields.io/github/v/release/sbaerlocher/tsmetrics)](https://github.com/sbaerlocher/tsmetrics/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Tailscale Prometheus exporter that combines API metadata with li
 
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://golang.org/)
 [![Docker](https://img.shields.io/badge/Docker-Available-2496ED?style=flat&logo=docker)](https://ghcr.io/sbaerlocher/tsmetrics)
-[![Pull Request](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml/badge.svg)](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml)
+[![CI](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml/badge.svg)](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sbaerlocher/tsmetrics)](https://goreportcard.com/report/github.com/sbaerlocher/tsmetrics)
 [![Release](https://img.shields.io/github/v/release/sbaerlocher/tsmetrics)](https://github.com/sbaerlocher/tsmetrics/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Tailscale Prometheus exporter that combines API metadata with li
 
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://golang.org/)
 [![Docker](https://img.shields.io/badge/Docker-Available-2496ED?style=flat&logo=docker)](https://ghcr.io/sbaerlocher/tsmetrics)
-[![CI/CD](https://github.com/sbaerlocher/tsmetrics/actions/workflows/ci.yml/badge.svg)](https://github.com/sbaerlocher/tsmetrics/actions/workflows/ci.yml)
+[![Pull Request](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml/badge.svg)](https://github.com/sbaerlocher/tsmetrics/actions/workflows/pull-request.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sbaerlocher/tsmetrics)](https://goreportcard.com/report/github.com/sbaerlocher/tsmetrics)
 [![Release](https://img.shields.io/github/v/release/sbaerlocher/tsmetrics)](https://github.com/sbaerlocher/tsmetrics/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary

- Point the CI badge at `pull-request.yml`. The referenced `ci.yml` was renamed in #121, so the badge rendered as "no status". Verified after the fix: the bare badge URL returns `Pull Request - passing`, so no `?event=` qualifier is needed — GitHub falls back to the most recent run when the default branch has none. Label kept as `CI` rather than `Pull Request`, which reads better in a badge row.
- Cut a `1.3.0` section covering what landed since `1.2.0`: the Prometheus alert rules and signed SBOM (#126), the Kubernetes state store startup retry (#173), the `WithJitter` move into `internal/errors`, and the Helm `METRICS_TOKEN` wiring (#125), which is filed under Security because the chart previously left `/metrics` unauthenticated.
- Add the missing `[Unreleased]` and `[1.2.0]` compare links at the bottom. All twelve version headings now have a matching reference definition.

Repo-internal changes since `1.2.0` (lefthook, `.dockerignore`, workflow renames, VS Code recommendations, the `mega-linter` removal) are deliberately left out — they change nothing for someone running the exporter.

## Test plan

- [ ] CI green
- [ ] `markdownlint` clean on both changed files (the pre-existing `README.md:938` line-length error is untouched by this PR)
- [ ] Badge renders a status rather than "no status"
- [ ] `[1.2.0]` compare link resolves. The `[Unreleased]` and `[1.3.0]` links point at a `v1.3.0` tag that `tag.yml` only creates on tag push, so they resolve after the release is cut, not at merge time.
