### PR TITLE
fix(ci): install syft so the release can complete

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,14 @@
       "depNameTemplate": "ghcr.io/sbaerlocher/tsmetrics",
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
+    },
+    {
+      "description": "Track annotated *_VERSION shell pins in workflow files",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+_VERSION=(?<currentValue>\\S+)"
+      ]
     }
   ],
   "packageRules": [

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,7 +10,6 @@ run-name: |
 permissions:
   contents: write
   packages: write
-  id-token: write
 
 jobs:
   setup:
@@ -69,11 +68,13 @@ jobs:
       # install syft, so GoReleaser aborts with "syft: executable file not
       # found in $PATH" after building the archives.
       pre-build-commands: |
+        set -euo pipefail
         # renovate: datasource=github-releases depName=anchore/syft
         SYFT_VERSION=v1.50.0
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-          | sh -s -- -b /usr/local/bin "$SYFT_VERSION"
-        syft --version
+        curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh" \
+          | sh -s -- -b "$RUNNER_TEMP/bin" "$SYFT_VERSION"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+        "$RUNNER_TEMP/bin/syft" --version
       extra-env: |
         VERSION_LONG=${{ needs.setup.outputs.version-long }}
         VERSION_SHORT=${{ needs.setup.outputs.version-short }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,6 +65,15 @@ jobs:
       # renovate: datasource=golang-version depName=golang
       go-version: "1.26"
       goreleaser-args: "release --clean"
+      # .goreleaser.yaml has an `sboms:` section, but release-go.yml does not
+      # install syft, so GoReleaser aborts with "syft: executable file not
+      # found in $PATH" after building the archives.
+      pre-build-commands: |
+        # renovate: datasource=github-releases depName=anchore/syft
+        SYFT_VERSION=v1.50.0
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+          | sh -s -- -b /usr/local/bin "$SYFT_VERSION"
+        syft --version
       extra-env: |
         VERSION_LONG=${{ needs.setup.outputs.version-long }}
         VERSION_SHORT=${{ needs.setup.outputs.version-short }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,19 +50,11 @@ checksum:
 sboms:
   - artifacts: archive
 
-# Keyless cosign signatures (Sigstore OIDC via GitHub Actions). Signs the
-# archives, checksums and SBOMs; .sig + .pem land next to each artifact.
-signs:
-  - cmd: cosign
-    certificate: "${artifact}.pem"
-    output: true
-    artifacts: checksum
-    args:
-      - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
-      - "${artifact}"
-      - --yes
+# Keyless cosign signing is disabled: it needs an OIDC token, and the release
+# job runs sbaerlocher/.github/.github/workflows/release-go.yml, which declares
+# only contents+packages — `id-token: write` on the caller does not propagate
+# into a reusable workflow. Re-add `signs:` once that workflow declares it and
+# installs cosign.
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,9 +52,10 @@ sboms:
 
 # Keyless cosign signing is disabled: it needs an OIDC token, and the release
 # job runs sbaerlocher/.github/.github/workflows/release-go.yml, which declares
-# only contents+packages — `id-token: write` on the caller does not propagate
-# into a reusable workflow. Re-add `signs:` once that workflow declares it and
-# installs cosign.
+# its own `permissions:` block (contents+packages only). A called workflow's
+# permissions block replaces the caller's, so the `id-token: write` granted in
+# tag.yml is dropped. Re-add `signs:` once that workflow declares `id-token:
+# write` and installs cosign.
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Release job installs syft, which `.goreleaser.yaml` needs for the `sboms:`
-  section. The `v1.3.0` tag produced no release at all: GoReleaser built and
-  archived the binaries, then aborted with `syft: executable file not found in
-  $PATH`, and the Docker and Helm jobs were skipped as a result.
-
-### Removed
-
-- Keyless cosign signing of `checksums.txt`. It requires an OIDC token, and the
-  reusable release workflow declares only `contents`/`packages` — `id-token:
-  write` on the caller does not propagate into a reusable workflow, so the step
-  could never have succeeded.
-
 ## [1.3.0] - 2026-08-04
 
 ### Added
@@ -38,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   process immediately, leaving the pod in CrashLoopBackOff even after the API
   server recovered. A permanently unreachable API server still surfaces as a
   CrashLoopBackOff once the attempts are exhausted.
+- Release job installs syft, which `.goreleaser.yaml` needs for the `sboms:`
+  section. Without it GoReleaser archived the binaries and then aborted with
+  `syft: executable file not found in $PATH`, taking the Docker and Helm jobs
+  down with it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release job installs syft, which `.goreleaser.yaml` needs for the `sboms:`
+  section. The `v1.3.0` tag produced no release at all: GoReleaser built and
+  archived the binaries, then aborted with `syft: executable file not found in
+  $PATH`, and the Docker and Helm jobs were skipped as a result.
+
+### Removed
+
+- Keyless cosign signing of `checksums.txt`. It requires an OIDC token, and the
+  reusable release workflow declares only `contents`/`packages` — `id-token:
+  write` on the caller does not propagate into a reusable workflow, so the step
+  could never have succeeded.
+
 ## [1.3.0] - 2026-08-04
 
 ### Added
@@ -15,8 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exporter's own health (down, stale scrape, scrape errors) and the tailnet
   (device offline, machine-key expiry, high DERP latency, tailnet-lock error,
   health messages), wired via `rule_files` in `prometheus.yml`.
-- Releases ship a syft SPDX SBOM plus keyless cosign signing of
-  `checksums.txt`, so consumers can verify the published artifacts.
+- Releases ship a syft SPDX SBOM per archive as a release asset.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

The `v1.3.0` tag produced **no release at all**. GoReleaser built and archived all four targets (3m51s), then aborted:

```
⨯ release failed after 4m2s  error=exec: "syft": executable file not found in $PATH
```

The Docker and Helm jobs depend on `go-release`, so both were skipped — no GitHub release, no assets, no image on ghcr.io.

Cause: #126 added an `sboms:` section to `.goreleaser.yaml`, but the release job runs `sbaerlocher/.github/.github/workflows/release-go.yml`, which installs neither syft nor cosign. `v1.3.0` was the first release since #126, so this is the first run that hit it.

- **syft**: installed via the existing `pre-build-commands` input, pinned to `v1.50.0`, fetched from the tag ref (not `main`) and installed into `$RUNNER_TEMP/bin`.
- **cosign `signs:`**: removed rather than fixed. Keyless signing needs an OIDC token; `release-go.yml` declares its own `permissions:` block omitting `id-token`, and a called workflow's block replaces the caller's. Re-enabling requires a change in `sbaerlocher/.github`.
- **`id-token: write`** dropped from `tag.yml` — with `signs:` gone it has no consumer, and neither `release-docker.yml` nor `release-helm.yml` does OIDC (verified against `@2026-08-03`).
- **Renovate customManager** added for annotated `*_VERSION` shell pins; the built-in `github-actions` manager only reads `key: value` pairs, so the annotation inside the block scalar was inert.
- Changelog: both entries folded into `[1.3.0]` since that tag published nothing, and the SBOM line no longer claims signing.

## Test plan

- [ ] CI green
- [x] `goreleaser check` passes against the edited config
- [x] syft install verified locally from the pinned tag URL (`syft 1.50.0`); `install.sh` at `v1.50.0` and `main` are byte-identical (same sha256)
- [x] Renovate regex verified against `tag.yml` — matches `anchore/syft` / `v1.50.0` / `github-releases`, file pattern matches
- [x] `release-go.yml@2026-08-03` accepts `pre-build-commands` and runs it in the same job immediately before the GoReleaser step
- [ ] After merge: re-tag and confirm the release completes, publishes SBOM assets, and that the Docker and Helm jobs run instead of being skipped

`tag.yml` only fires on tag push, so no PR check exercises this path — the last box needs a real tag.
