### PR TITLE
fix(ci): drop pre-build-commands from the release workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -64,17 +64,6 @@ jobs:
       # renovate: datasource=golang-version depName=golang
       go-version: "1.27"
       goreleaser-args: "release --clean"
-      # .goreleaser.yaml has an `sboms:` section, but release-go.yml does not
-      # install syft, so GoReleaser aborts with "syft: executable file not
-      # found in $PATH" after building the archives.
-      pre-build-commands: |
-        set -euo pipefail
-        # renovate: datasource=github-releases depName=anchore/syft
-        SYFT_VERSION=v1.51.1
-        curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh" \
-          | sh -s -- -b "$RUNNER_TEMP/bin" "$SYFT_VERSION"
-        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-        "$RUNNER_TEMP/bin/syft" --version
       extra-env: |
         VERSION_LONG=${{ needs.setup.outputs.version-long }}
         VERSION_SHORT=${{ needs.setup.outputs.version-short }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release workflow no longer passes `pre-build-commands:` to
+  `release-go.yml`. The input was removed upstream in `sbaerlocher/.github`,
+  and since GitHub validates reusable-workflow inputs before dispatch, the
+  first v1.3.1 tag push failed with `startup_failure` — no job ran and no log
+  was produced. The input existed only to install syft for the `sboms:`
+  section in `.goreleaser.yaml`; `release-go.yml@2026-08-31` now installs syft
+  itself, so the workaround is dropped rather than replaced.
+
 - CI now pins Go 1.27 in the `pull-request`, `tag` and `nightly-security`
   workflows. Renovate raised `go.mod` to 1.27.0 while the reusable-workflow
   calls still passed `go-version: "1.26"`, and with `GOTOOLCHAIN=local` every


### PR DESCRIPTION
## Summary

Unblocks the v1.3.1 release.

The v1.3.1 tag push failed with `startup_failure`: `tag.yml` passed
`pre-build-commands:` to `release-go.yml`, an input that no longer exists
there. GitHub validates reusable-workflow inputs before dispatch, so no job
started and no log was produced — the tag `v1.3.1` is pushed, but no release
was ever built and `Latest` is still v1.3.0.

Renovate had been raising the `@date-tag` ref past the removal (the input is
already gone at `2026-08-16`) without checking input compatibility, and no
release had been cut since v1.3.0, so nothing surfaced it until now.

The input existed only to put syft on PATH for the `sboms:` section in
`.goreleaser.yaml`. `release-go.yml@2026-08-31` installs syft itself as of
sbaerlocher/.github#360, so the workaround is dropped rather than replaced.

The CHANGELOG entry for 1.3.1 is amended in place, since that release has not
shipped yet.

## Test plan

- Every input in `tag.yml` validated against the `workflow_call.inputs` schema
  of each reusable workflow at `@2026-08-31`: `go-release`, `docker-release`
  and `helm-release` all report `inputs ok` — the same check that would have
  caught the original breakage.
- Confirmed `release-go.yml@2026-08-31` contains the `Install syft` step
  (fetched at that ref, post-merge).
- Workflow YAML parses; `yaml-lint` clean; `markdownlint CHANGELOG.md` clean.
- End-to-end verification is the retagged v1.3.1 release run after this merges.

After merge: delete and re-push the `v1.3.1` tag so it points at a commit whose
workflow actually dispatches.
